### PR TITLE
FIX reformulate API

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -103,7 +103,7 @@ _**Response code**_
 
 _**Response headers**_
 
-* Return the header `Location` with the value of the path used to create the subscription (I.E : `/sets/st01`) 
+* Return the header `Location` with the value of the path used to create the set (I.E : `/sets/st01`) 
 when the creation succeeds (Response code 201).
 
 _**Response payload**_
@@ -292,7 +292,7 @@ _**Response code**_
 
 _**Response headers**_
 
-* Return the header `Location` with the value of the path used to create the subscription (I.E : `/sets/st01/fdas/fda01`) 
+* Return the header `Location` with the value of the path used to create the FDA (I.E : `/sets/st01/fdas/fda01`) 
 when the creation succeeds (Response code 201).
 
 _**Response payload**_
@@ -362,7 +362,7 @@ TBD
 
 _**Response code**_
 
-* Successful operation uses 201 Created
+* Successful operation uses 204 No Content
 * Errors use a non-2xx and (optionally) an error payload. See subsection on [Error Responses](#error-responses) for
   more details.
 
@@ -436,7 +436,7 @@ _**Response payload**_
 
 TBD
 
-## Old fraft API (to be removed)
+## Old draft API (to be removed)
 
 ## storeSet (TEMPORAL)
 


### PR DESCRIPTION
Related with issue #15 

This PR is inspired in https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md style.

Some comments:

* It would be great to have a database_model.md side document describing the MongoDB datamodel (this one can be used as inspiration: https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/admin/database_model.md). As we have been discussing before, although the API considers to types of resources (sets and FDAs) I think it is achievable with one single collection (in the same way than in Orion we have two types of resources, entities and attributes, but we have only one entities collection)
* Create set and regenerate set operations can take a lot of time (minutes) so probably should be designed in an async way. Thus, the responde in the API should be fast, but maybe a field in the set should indication the status (i.e. `"status": "fetching"` -> `"status": "completed"`)
* Details on how to implement the doQuery operation to cope with Pentaho CDA compatibility is pending, but seems afordable
* The `description` field has not been considered so far, but I think it would be an easy addition
* The old API design is still in the document, but it should be removed once we validate the new design
* ToC, examples and Error Response section are pending (minor)