### PR TITLE
Correct API header for doQuery endpoint

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -463,7 +463,7 @@ The payload is an array of JSON objects, each one being a record result of the s
 ]
 ```
 
-#### doQuery (Petaho CDA legacy support)
+#### Query `GET /doQuery` (Pentaho CDA legacy support)
 
 Same operation implemented by Pentaho CDA, in order to provide backward compatibility with existing CDA clients with
 minimal impact. This method is a kind of wrapper of `query`


### PR DESCRIPTION
Updated the header for the doQuery API to reflect the correct naming convention.