### PR TITLE
fix coverage tests using nyc and c8

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,6 @@
+{
+  "reporter": ["lcov", "text-summary"],
+  "reportsDirectory": "coverage",
+  "include": ["lib/**/*.js", "*.js"],
+  "exclude": ["test/**", "**/node_modules/**"]
+}

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,10 @@
+{
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["lcov", "text-summary"],
+  "report-dir": "coverage",
+  "temp-dir": ".nyc_output",
+  "include": ["lib/**/*.js", "*.js"],
+  "exclude": ["test/**", "**/node_modules/**"],
+  "extension": [".js"]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,8 @@ export default {
   testEnvironment: 'node',
   testMatch: ['**/*.test.js'],
   verbose: true,
-  collectCoverage: true,
+  collectCoverage: false,
   coverageDirectory: 'coverage',
-  collectCoverageFrom: ['lib/**/*.js', '!**/node_modules/**'],
-  coverageReporters: ['text', 'lcov'],
+  collectCoverageFrom: ['lib/**/*.js', '*.js', '!**/node_modules/**'],
+  coverageReporters: ['text-summary', 'lcov'],
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prettier": "prettier --config .prettierrc.json --write '**/**/**/**/*.js' '**/**/**/*.js' '**/**/*.js' '**/*.js' '*.js'",
     "start": "node .",
     "test": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand",
-    "test:coverage": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand --coverage --coverageReporters=lcov --coverageReporters=text-summary"
+    "test:coverage": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules c8 --reporter=lcov --reporter=text-summary --reports-dir=coverage jest --runInBand"
+
   },
   "engines": {
     "node": ">=24"
@@ -22,26 +23,28 @@
     "@aws-sdk/lib-storage": "~3.934.0",
     "@duckdb/node-api": "~1.4.1-r.1",
     "express": "5.1.0",
+    "logops": "~2.1.2",
     "mongodb": "~7.0.0",
     "pg": "~8.16.3",
     "pg-copy-streams": "~7.0.0",
-    "logops": "~2.1.2",
     "uuid": "~11.1.0"
   },
   "devDependencies": {
-    "eslint": "~8.18.0",
-    "lint-staged": "~12.3.8",
     "@aws-sdk/client-s3": "~3.972.0",
     "ajv": "~8.17.1",
+    "c8": "^10.1.3",
     "dotenv": "~17.2.3",
+    "eslint": "~8.18.0",
     "eslint-config-tamia": "~8.0.0",
     "eslint-plugin-prettier": "~4.0.0",
     "globals": "~16.5.0",
     "husky": "~4.3.8",
     "jest": "~29.7.0",
     "jest-mock-extended": "4.0.0",
+    "lint-staged": "~12.3.8",
     "lodash": "~4.17.21",
     "nodemon": "~3.1.10",
+    "nyc": "^17.1.0",
     "prettier": "~2.7.1",
     "supertest": "~7.2.2",
     "testcontainers": "~11.11.0"


### PR DESCRIPTION
 $ npm run test:coverage
 ```
 PASS  test/integration/fda.proc.int.test.js (9.057 s)
  FDA API - integration (run app as child process)
    ✓ POST /fdas creates an FDA (uploads CSV then converts to Parquet) (131 ms)
    ✓ GET /fdas returns list (4 ms)
    ✓ POST /fdas/:fdaId/das + GET /query executes DuckDB against Parquet (12 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        9.11 s, estimated 10 s
Ran all test suites.

=============================== Coverage summary ===============================
Statements   : 70.13% ( 963/1373 )
Branches     : 78.66% ( 59/75 )
Functions    : 68.62% ( 35/51 )
Lines        : 70.13% ( 963/1373 )
================================================================================
```
