### PR TITLE
DA creation: check DA compatibility with baseQuery

### DIFF
--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -175,7 +175,7 @@ export async function putDA(service, fdaId, daId, description, userQuery) {
 
   try {
     const query = buildDAQuery(service, fdaId, userQuery);
-    await storeCachedQuery(service, fdaId, daId, query);
+    await storeCachedQuery(conn, service, fdaId, daId, query);
     await updateDA(service, fdaId, daId, description, userQuery);
   } finally {
     await releaseDBConnection(conn);

--- a/src/lib/utils/db.js
+++ b/src/lib/utils/db.js
@@ -114,7 +114,7 @@ export async function runPreparedStatement(conn, service, fdaId, daId, params) {
       );
     }
     query = da.query;
-    await storeCachedQuery(service, fdaId, daId, query);
+    await storeCachedQuery(conn, service, fdaId, daId, query);
   }
 
   const stmt = await conn.prepare(query);
@@ -161,7 +161,7 @@ export async function runPreparedStatementStream(
       );
     }
     query = da.query;
-    await storeCachedQuery(service, fdaId, daId, query);
+    await storeCachedQuery(conn, service, fdaId, daId, query);
   }
 
   const stmt = await conn.prepare(query);


### PR DESCRIPTION
In the pr #17 we changed the way of interacting with `DuckDB`, adding a pool of connections. This can mess with the use of the `DuckDB` prepared statements because they are tied to the connection that created them. Because of that the way the statements are stored in the FDA "cache" has changed and now when creating a `DA` `DuckDB` no longer checks the query, no longer warning about incompatibility between the DA query and the FDA base query.

This pr adds the creation of the pStatement so DuckDb makes the "compatibility" check but it doesn't store it in FDA memory, removing duckDb connection related problems.