### PR TITLE
.env.example: add remaining envVars to example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@
 FDA_NODE_ENV=development
 FDA_SERVER_PORT=8080
 
-# Roles
+# Instance Roles
 FDA_ROLE_APISERVER=true
 FDA_ROLE_FETCHER=true
 

--- a/doc/04_config_operational_guide.md
+++ b/doc/04_config_operational_guide.md
@@ -97,7 +97,7 @@ Variables related to MongoDB:
 FDA_NODE_ENV=development
 FDA_SERVER_PORT=8080
 
-# Roles
+# Instance Roles
 FDA_ROLE_APISERVER=true
 FDA_ROLE_FETCHER=true
 


### PR DESCRIPTION
This pr adds a couple `envVars` to the `.env.example` that where left out and orders them to match the documentation (for easy reading).