### PR TITLE
Fix output format

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,9 @@
     "ecmaVersion": 2024,
     "sourceType": "module"
   },
+  "env": {
+    "es2020": true
+  },
   "plugins": ["prettier"],
   "rules": {
     "prettier/prettier": "error",

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,6 +4,8 @@
 - Fix: value of default params are checked when creating DA (#107)
 - Fix: query operation is now REST-like using `GET /{visibility}/fdas/{fdaId}/das/{daId}/data` instead of `/query` (#62)
 - Add: visibility-based data access segmentation (`public` / `private`) with FDA visibility validation, including CDA `doQuery` compatibility path handling (#21)
+- Fix: `fresh=true` queries now serialize dates as ISO 8601 strings and integers as numbers consistently with the cached Parquet path, across JSON, NDJSON and CSV outputs (#137)
+- Fix: `outputType` query parameter on `GET /{visibility}/fdas/{fdaId}/das/{daId}/data` is now rejected; format negotiation is exclusively `Accept`-header-driven (#137)
 - Fix: FDA now includes `servicePath` in Mongo unique index (`service + servicePath + fdaId`) and operational storage layout is now scoped as `/service/servicePath/fdaId/` (#132)
 - Fix: forbids the usage of `/` as servicePath
 - Fix: sanitize FDA retrieval payloads to avoid redundant/internal fields (#129)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -5,7 +5,7 @@
 - Fix: query operation is now REST-like using `GET /{visibility}/fdas/{fdaId}/das/{daId}/data` instead of `/query` (#62)
 - Add: visibility-based data access segmentation (`public` / `private`) with FDA visibility validation, including CDA `doQuery` compatibility path handling (#21)
 - Fix: `fresh=true` queries now serialize dates as ISO 8601 strings and integers as numbers consistently with the cached Parquet path, across JSON, NDJSON and CSV outputs (#137)
-- Fix: `outputType` query parameter on `GET /{visibility}/fdas/{fdaId}/das/{daId}/data` is now rejected; format negotiation is exclusively `Accept`-header-driven (#137)
+- Fix: format negotiation done using the `Accept` HTTP standard mechanism (outputType is no longer supported, except in the Pentaho legacy operation) (#137)
 - Fix: FDA now includes `servicePath` in Mongo unique index (`service + servicePath + fdaId`) and operational storage layout is now scoped as `/service/servicePath/fdaId/` (#132)
 - Fix: forbids the usage of `/` as servicePath
 - Fix: sanitize FDA retrieval payloads to avoid redundant/internal fields (#129)

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -1227,7 +1227,7 @@ _**Response headers**_
 
 | `Accept` request header                                                                           | `Content-Type`                                                      | `Content-Disposition`                 |
 | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------- |
-| `application/json` or missing/`*/*`                                                               | `application/json`                                                  | —                                     |
+| `application/json`, missing, or `*/*`                                                             | `application/json`                                                  | —                                     |
 | `application/x-ndjson`                                                                            | `application/x-ndjson`                                              | —                                     |
 | `text/csv`                                                                                        | `text/csv; charset=utf-8`                                           | `attachment; filename="results.csv"`  |
 | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` or `application/vnd.ms-excel` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` | `attachment; filename="results.xlsx"` |

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -70,27 +70,28 @@ All error responses follow this structure:
 
 ### HTTP status codes
 
-| Code | Status                | Error Code             | Cause                                                                                                                                                                             |
-| ---- | --------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 400  | Bad Request           | `BadRequest`           | Missing or invalid values in request body, headers, or query parameters. `Fiware-Service`, `Fiware-ServicePath`, and `visibility` (path segment) are required for all operations. |
-| 400  | Bad Request           | `BadRequest`           | An unsupported `outputType` value was provided. Allowed values: `json`, `csv`, `xls`.                                                                                             |
-| 400  | Bad Request           | `InvalidVisibility`    | The `visibility` path segment is not one of the allowed values (`public`, `private`).                                                                                             |
-| 400  | Bad Request           | `InvalidServicePath`   | The `Fiware-ServicePath` header value is not a valid non-root absolute path (e.g. `/servicePath/site`). The root path `/` is not allowed.                                         |
-| 400  | Bad Request           | `InvalidQueryParam`    | Some of the params in the request don't comply with the [params](#params) array restrictions.                                                                                     |
-| 403  | Forbidden             | `VisibilityMismatch`   | The FDA exists but was created under a different `visibility`. Cannot access a private FDA through a public route and vice-versa.                                                 |
-| 400  | Bad Request           | `PartitionError`       | Some of the params related to the creation of the parquet partition don't comply with the [object storage configuration](#object-storage-configuration-objstgconf) requirements.  |
-| 400  | Bad Request           | `CleaningError`        | Trying to remove a non partitioned FDA or incorrect value in the [delete interval key](#refresh-policy-object).                                                                   |
-| 404  | Not Found             | `FDANotFound`          | The requested FDA was not found.                                                                                                                                                  |
-| 404  | Not Found             | `DaNotFound`           | The requested Data Access (DA) was not found.                                                                                                                                     |
-| 409  | Conflict              | `DuplicatedKey`        | The resource already exists in the database. Attempting to create a duplicate resource.                                                                                           |
-| 429  | Too Many Requests     | `TooManyFreshQueries`  | The number of concurrent `fresh=true` queries exceeded `FDA_MAX_CONCURRENT_FRESH_QUERIES`.                                                                                        |
-| 409  | Conflict              | `FDAUnavailable`       | FDA `exampleId` is not queryable yet because the first fetch has not completed.                                                                                                   |
-| 500  | Internal Server Error | `S3ServerError`        | An error occurred in the S3 object storage component.                                                                                                                             |
-| 500  | Internal Server Error | `DuckDBServerError`    | An error occurred in the DuckDB component.                                                                                                                                        |
-| 500  | Internal Server Error | `MongoDBServerError`   | An error occurred in the MongoDB component.                                                                                                                                       |
-| 503  | Service Unavailable   | `UploadError`          | Connection error with the PostgreSQL database component.                                                                                                                          |
-| 503  | Service Unavailable   | `SyncQueriesDisabled`  | A request was sent with `fresh=true` but the API instance is running with `FDA_ROLE_SYNCQUERIES=false`.                                                                           |
-| 503  | Service Unavailable   | `MongoConnectionError` | Connection error with the MongoDB component.                                                                                                                                      |
+| Code | Status                | Error Code             | Cause                                                                                                                                                                                       |
+| ---- | --------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 400  | Bad Request           | `BadRequest`           | Missing or invalid values in request body, headers, or query parameters. `Fiware-Service`, `Fiware-ServicePath`, and `visibility` (path segment) are required for all operations.           |
+| 400  | Bad Request           | `BadRequest`           | Query param `outputType` is no longer supported in `GET /{visibility}/fdas/{fdaId}/das/{daId}/data`. Use the `Accept` header for content negotiation.                                       |
+| 400  | Bad Request           | `InvalidVisibility`    | The `visibility` path segment is not one of the allowed values (`public`, `private`).                                                                                                       |
+| 400  | Bad Request           | `InvalidServicePath`   | The `Fiware-ServicePath` header value is not a valid non-root absolute path (e.g. `/servicePath/site`). The root path `/` is not allowed.                                                   |
+| 400  | Bad Request           | `InvalidQueryParam`    | Some of the params in the request don't comply with the [params](#params) array restrictions.                                                                                               |
+| 403  | Forbidden             | `VisibilityMismatch`   | The FDA exists but was created under a different `visibility`. Cannot access a private FDA through a public route and vice-versa.                                                           |
+| 400  | Bad Request           | `PartitionError`       | Some of the params related to the creation of the parquet partition don't comply with the [object storage configuration](#object-storage-configuration-objstgconf) requirements.            |
+| 400  | Bad Request           | `CleaningError`        | Trying to remove a non partitioned FDA or incorrect value in the [delete interval key](#refresh-policy-object).                                                                             |
+| 404  | Not Found             | `FDANotFound`          | The requested FDA was not found.                                                                                                                                                            |
+| 404  | Not Found             | `DaNotFound`           | The requested Data Access (DA) was not found.                                                                                                                                               |
+| 409  | Conflict              | `DuplicatedKey`        | The resource already exists in the database. Attempting to create a duplicate resource.                                                                                                     |
+| 429  | Too Many Requests     | `TooManyFreshQueries`  | The number of concurrent `fresh=true` queries exceeded `FDA_MAX_CONCURRENT_FRESH_QUERIES`.                                                                                                  |
+| 406  | Not Acceptable        | `NotAcceptable`        | `Accept` header does not allow any supported response format (`application/json`, `application/x-ndjson`, `text/csv`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`). |
+| 409  | Conflict              | `FDAUnavailable`       | FDA `exampleId` is not queryable yet because the first fetch has not completed.                                                                                                             |
+| 500  | Internal Server Error | `S3ServerError`        | An error occurred in the S3 object storage component.                                                                                                                                       |
+| 500  | Internal Server Error | `DuckDBServerError`    | An error occurred in the DuckDB component.                                                                                                                                                  |
+| 500  | Internal Server Error | `MongoDBServerError`   | An error occurred in the MongoDB component.                                                                                                                                                 |
+| 503  | Service Unavailable   | `UploadError`          | Connection error with the PostgreSQL database component.                                                                                                                                    |
+| 503  | Service Unavailable   | `SyncQueriesDisabled`  | A request was sent with `fresh=true` but the API instance is running with `FDA_ROLE_SYNCQUERIES=false`.                                                                                     |
+| 503  | Service Unavailable   | `MongoConnectionError` | Connection error with the MongoDB component.                                                                                                                                                |
 
 ### Common error scenarios
 
@@ -1190,12 +1191,13 @@ _**Request path parameters**_
 
 _**Request query parameters**_
 
-| Parameter    | Optional | Description                                                                                                                                              | Example |
-| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `outputType` | ✓        | Format of the returned results. **Default:** `json`. Allowed values: `json`, `csv`, `xls`.                                                               | `csv`   |
-| `fresh`      | ✓        | If `true`, executes the DA directly against PostgreSQL instead of the cached Parquet snapshot. Requires `FDA_ROLE_SYNCQUERIES=true` in the API instance. | `true`  |
+| Parameter | Optional | Description                                                                                                                                              | Example |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `fresh`   | ✓        | If `true`, executes the DA directly against PostgreSQL instead of the cached Parquet snapshot. Requires `FDA_ROLE_SYNCQUERIES=true` in the API instance. | `true`  |
 
 Additionally, the DA-specific parameters must be included in the query string together with the previous ones.
+
+`outputType` is not accepted anymore in this endpoint. If provided, the API returns `400 BadRequest`.
 
 _**Request headers**_
 
@@ -1225,30 +1227,35 @@ _**Behavior note**_
 
 _**Response headers**_
 
-| `outputType` value | `Content-Type`                                                      | `Content-Disposition`                 |
-| ------------------ | ------------------------------------------------------------------- | ------------------------------------- |
-| `json` (default)   | `application/json`                                                  | —                                     |
-| `csv`              | `text/csv`                                                          | `attachment; filename="results.csv"`  |
-| `xls`              | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` | `attachment; filename="results.xlsx"` |
+| `Accept` request header                                                                           | `Content-Type`                                                      | `Content-Disposition`                 |
+| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------- |
+| `application/json` or missing/`*/*`                                                               | `application/json`                                                  | —                                     |
+| `application/x-ndjson`                                                                            | `application/x-ndjson`                                              | —                                     |
+| `text/csv`                                                                                        | `text/csv; charset=utf-8`                                           | `attachment; filename="results.csv"`  |
+| `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` or `application/vnd.ms-excel` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` | `attachment; filename="results.xlsx"` |
 
 _**Response payload**_
 
-Depends on `outputType`:
+Depends on `Accept`:
 
--   `json` (default): array of JSON objects, each one being a record result of the stored parameterized query.
--   `csv`: comma-separated values file. The first row contains column names. Values containing commas, double-quotes or
-    newlines are quoted.
--   `xls`: Excel workbook (`.xlsx` format, Office Open XML). The first row contains column names.
+-   `application/json` (or default): array of JSON objects, each one being a record result of the stored parameterized
+    query.
+-   `application/x-ndjson`: one JSON object per line (streamed response).
+-   `text/csv`: comma-separated values file. The first row contains column names. Values containing commas,
+    double-quotes or newlines are quoted.
+-   spreadsheet MIME types: Excel workbook (`.xlsx` format, Office Open XML). The first row contains column names.
 
-_**Output type and NDJSON streaming**_
+_**Content negotiation and serialization notes**_
 
--   `outputType` applies to the standard (buffered) response path.
--   If the client sets the `Accept: application/x-ndjson` header, NDJSON streaming takes precedence over `outputType`
-    and the server responds with `Content-Type: application/x-ndjson`, streaming one JSON object per line.
--   NDJSON output uses numeric types for integer columns (BigInt values are converted to numbers before serialization).
+-   Response format is negotiated only through the `Accept` header.
+-   If `Accept` does not include a supported format, the API returns `406 NotAcceptable`.
+-   `outputType` query parameter is rejected with `400 BadRequest`.
+-   Date values are normalized to strings (ISO 8601) before JSON/NDJSON/CSV serialization.
+-   Integer database values are normalized to numeric JSON values.
 -   The `fresh` parameter can be combined with all output modes.
 -   With `fresh=true` and `Accept: application/x-ndjson`, results are streamed incrementally from PostgreSQL using a
     cursor to avoid loading full result sets in memory.
+-   With `Accept: text/csv`, responses are streamed in both cached and fresh modes.
 
 _**Example Request (without DA parameters):**_
 
@@ -1314,18 +1321,20 @@ _**Example Response:**_
 _**Example Request (CSV output):**_
 
 ```bash
-curl -i -X GET "http://localhost:8080/public/fdas/fda_alarms/das/da_all_alarms/data?outputType=csv" \
+curl -i -X GET "http://localhost:8080/public/fdas/fda_alarms/das/da_all_alarms/data" \
   -H "Fiware-Service: my-bucket" \
   -H "Fiware-ServicePath: /servicePath" \
+    -H "Accept: text/csv" \
   --output results.csv
 ```
 
 _**Example Request (Excel output):**_
 
 ```bash
-curl -i -X GET "http://localhost:8080/public/fdas/fda_alarms/das/da_all_alarms/data?outputType=xls" \
+curl -i -X GET "http://localhost:8080/public/fdas/fda_alarms/das/da_all_alarms/data" \
   -H "Fiware-Service: my-bucket" \
   -H "Fiware-ServicePath: /servicePath" \
+    -H "Accept: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" \
   --output results.xlsx
 ```
 

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -73,7 +73,7 @@ All error responses follow this structure:
 | Code | Status                | Error Code             | Cause                                                                                                                                                                                       |
 | ---- | --------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 400  | Bad Request           | `BadRequest`           | Missing or invalid values in request body, headers, or query parameters. `Fiware-Service`, `Fiware-ServicePath`, and `visibility` (path segment) are required for all operations.           |
-| 400  | Bad Request           | `BadRequest`           | Query param `outputType` is no longer supported in `GET /{visibility}/fdas/{fdaId}/das/{daId}/data`. Use the `Accept` header for content negotiation.                                       |
+| 400  | Bad Request           | `BadRequest`           | Invalid or unsupported query fields were provided (for example, using `outputType` in `GET /{visibility}/fdas/{fdaId}/das/{daId}/data`).                                                    |
 | 400  | Bad Request           | `InvalidVisibility`    | The `visibility` path segment is not one of the allowed values (`public`, `private`).                                                                                                       |
 | 400  | Bad Request           | `InvalidServicePath`   | The `Fiware-ServicePath` header value is not a valid non-root absolute path (e.g. `/servicePath/site`). The root path `/` is not allowed.                                                   |
 | 400  | Bad Request           | `InvalidQueryParam`    | Some of the params in the request don't comply with the [params](#params) array restrictions.                                                                                               |
@@ -1197,7 +1197,7 @@ _**Request query parameters**_
 
 Additionally, the DA-specific parameters must be included in the query string together with the previous ones.
 
-`outputType` is not accepted anymore in this endpoint. If provided, the API returns `400 BadRequest`.
+`outputType` is not accepted in this endpoint. If provided, the API returns `400 BadRequest` as an invalid query field.
 
 _**Request headers**_
 
@@ -1249,7 +1249,7 @@ _**Content negotiation and serialization notes**_
 
 -   Response format is negotiated only through the `Accept` header.
 -   If `Accept` does not include a supported format, the API returns `406 NotAcceptable`.
--   `outputType` query parameter is rejected with `400 BadRequest`.
+-   Unsupported query fields (including `outputType`) are rejected with `400 BadRequest`.
 -   Date values are normalized to strings (ISO 8601) before JSON/NDJSON/CSV serialization.
 -   Integer database values are normalized to numeric JSON values.
 -   The `fresh` parameter can be combined with all output modes.

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -1197,8 +1197,6 @@ _**Request query parameters**_
 
 Additionally, the DA-specific parameters must be included in the query string together with the previous ones.
 
-`outputType` is not accepted in this endpoint. If provided, the API returns `400 BadRequest` as an invalid query field.
-
 _**Request headers**_
 
 | Header               | Optional | Description                                                          | Example        |

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -1245,9 +1245,9 @@ Depends on `Accept`:
 
 _**Content negotiation and serialization notes**_
 
--   Response format is negotiated only through the `Accept` header.
+-   Response format is negotiated only through the `Accept` header (using the [standard HTTP content negotiation mechanism](https://datatracker.ietf.org/doc/html/rfc2616#section-12)).
 -   If `Accept` does not include a supported format, the API returns `406 NotAcceptable`.
--   Unsupported query fields (including `outputType`) are rejected with `400 BadRequest`.
+-   Unsupported query fields are rejected with `400 BadRequest`.
 -   Date values are normalized to strings (ISO 8601) before JSON/NDJSON/CSV serialization.
 -   Integer database values are normalized to numeric JSON values.
 -   The `fresh` parameter can be combined with all output modes.

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -77,15 +77,15 @@ All error responses follow this structure:
 | 400  | Bad Request           | `InvalidVisibility`    | The `visibility` path segment is not one of the allowed values (`public`, `private`).                                                                                                       |
 | 400  | Bad Request           | `InvalidServicePath`   | The `Fiware-ServicePath` header value is not a valid non-root absolute path (e.g. `/servicePath/site`). The root path `/` is not allowed.                                                   |
 | 400  | Bad Request           | `InvalidQueryParam`    | Some of the params in the request don't comply with the [params](#params) array restrictions.                                                                                               |
-| 403  | Forbidden             | `VisibilityMismatch`   | The FDA exists but was created under a different `visibility`. Cannot access a private FDA through a public route and vice-versa.                                                           |
 | 400  | Bad Request           | `PartitionError`       | Some of the params related to the creation of the parquet partition don't comply with the [object storage configuration](#object-storage-configuration-objstgconf) requirements.            |
 | 400  | Bad Request           | `CleaningError`        | Trying to remove a non partitioned FDA or incorrect value in the [delete interval key](#refresh-policy-object).                                                                             |
+| 403  | Forbidden             | `VisibilityMismatch`   | The FDA exists but was created under a different `visibility`. Cannot access a private FDA through a public route and vice-versa.                                                           |
 | 404  | Not Found             | `FDANotFound`          | The requested FDA was not found.                                                                                                                                                            |
 | 404  | Not Found             | `DaNotFound`           | The requested Data Access (DA) was not found.                                                                                                                                               |
-| 409  | Conflict              | `DuplicatedKey`        | The resource already exists in the database. Attempting to create a duplicate resource.                                                                                                     |
-| 429  | Too Many Requests     | `TooManyFreshQueries`  | The number of concurrent `fresh=true` queries exceeded `FDA_MAX_CONCURRENT_FRESH_QUERIES`.                                                                                                  |
 | 406  | Not Acceptable        | `NotAcceptable`        | `Accept` header does not allow any supported response format (`application/json`, `application/x-ndjson`, `text/csv`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`). |
+| 409  | Conflict              | `DuplicatedKey`        | The resource already exists in the database. Attempting to create a duplicate resource.                                                                                                     |
 | 409  | Conflict              | `FDAUnavailable`       | FDA `exampleId` is not queryable yet because the first fetch has not completed.                                                                                                             |
+| 429  | Too Many Requests     | `TooManyFreshQueries`  | The number of concurrent `fresh=true` queries exceeded `FDA_MAX_CONCURRENT_FRESH_QUERIES`.                                                                                                  |
 | 500  | Internal Server Error | `S3ServerError`        | An error occurred in the S3 object storage component.                                                                                                                                       |
 | 500  | Internal Server Error | `DuckDBServerError`    | An error occurred in the DuckDB component.                                                                                                                                                  |
 | 500  | Internal Server Error | `MongoDBServerError`   | An error occurred in the MongoDB component.                                                                                                                                                 |
@@ -1245,7 +1245,8 @@ Depends on `Accept`:
 
 _**Content negotiation and serialization notes**_
 
--   Response format is negotiated only through the `Accept` header (using the [standard HTTP content negotiation mechanism](https://datatracker.ietf.org/doc/html/rfc2616#section-12)).
+-   Response format is negotiated only through the `Accept` header (using the
+    [standard HTTP content negotiation mechanism](https://datatracker.ietf.org/doc/html/rfc2616#section-12)).
 -   If `Accept` does not include a supported format, the API returns `406 NotAcceptable`.
 -   Unsupported query fields are rejected with `400 BadRequest`.
 -   Date values are normalized to strings (ISO 8601) before JSON/NDJSON/CSV serialization.

--- a/doc/postman/README.md
+++ b/doc/postman/README.md
@@ -34,3 +34,14 @@ Before sending requests, create or update a Postman environment and define the f
 
 > ⚠️ These variables are required. The requests in the collection depend on them and will not work correctly if they are
 > not properly configured.
+
+---
+
+### 3. Content negotiation for DA data endpoint
+
+For `GET /{visibility}/fdas/{fdaId}/das/{daId}/data`, response format is selected only through the `Accept` header:
+
+-   `application/json` (or missing/`*/*`) returns JSON.
+-   `application/x-ndjson` returns NDJSON stream.
+-   `text/csv` returns CSV stream.
+-   `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` returns XLSX.

--- a/doc/postman/fiware-data-access.postman_collection.json
+++ b/doc/postman/fiware-data-access.postman_collection.json
@@ -470,10 +470,15 @@
 								"key": "Fiware-ServicePath",
 								"value": "{{Fiware-ServicePath}}",
 								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "text/csv",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/{{visibility}}/fdas/{{fdaId}}/das/{{daId}}/data?outputType=csv&animalname=TUNA&activity=12",
+							"raw": "{{url}}/{{visibility}}/fdas/{{fdaId}}/das/{{daId}}/data?animalname=TUNA&activity=12",
 							"host": [
 								"{{url}}"
 							],
@@ -486,10 +491,6 @@
 								"data"
 							],
 							"query": [
-								{
-									"key": "outputType",
-									"value": "csv"
-								},
 								{
 									"key": "animalname",
 									"value": "TUNA"
@@ -517,10 +518,15 @@
 								"key": "Fiware-ServicePath",
 								"value": "{{Fiware-ServicePath}}",
 								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/{{visibility}}/fdas/{{fdaId}}/das/{{daId}}/data?outputType=xls&animalname=TUNA&activity=12",
+							"raw": "{{url}}/{{visibility}}/fdas/{{fdaId}}/das/{{daId}}/data?animalname=TUNA&activity=12",
 							"host": [
 								"{{url}}"
 							],
@@ -533,10 +539,6 @@
 								"data"
 							],
 							"query": [
-								{
-									"key": "outputType",
-									"value": "xls"
-								},
 								{
 									"key": "animalname",
 									"value": "TUNA"

--- a/src/index.js
+++ b/src/index.js
@@ -381,21 +381,42 @@ app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
   const { visibility, fdaId, daId } = req.params;
   const service = req.get('Fiware-Service');
   const servicePath = req.get('Fiware-ServicePath');
-  const accept = req.get('Accept') || 'application/json';
+  const accept = req.get('Accept');
   const fresh = parseBooleanQueryParam(req.query.fresh, 'fresh');
   let outputType = 'json';
 
-  if (accept.includes('application/x-ndjson')) {
+  if (!accept || accept.trim() === '*/*') {
+    outputType = 'json';
+  } else if (
+    accept.includes('application/x-ndjson') &&
+    req.accepts('application/x-ndjson')
+  ) {
     outputType = 'ndjson';
-  } else if (accept.includes('text/csv')) {
+  } else if (accept.includes('text/csv') && req.accepts('text/csv')) {
     outputType = 'csv';
   } else if (
-    accept.includes(
+    (accept.includes(
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    ) ||
-    accept.includes('application/vnd.ms-excel')
+    ) &&
+      req.accepts(
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      )) ||
+    (accept.includes('application/vnd.ms-excel') &&
+      req.accepts('application/vnd.ms-excel'))
   ) {
     outputType = 'xls';
+  } else if (
+    accept.includes('application/json') ||
+    accept.includes('application/*') ||
+    accept.includes('*/*')
+  ) {
+    outputType = 'json';
+  } else {
+    return res.status(406).json({
+      error: 'NotAcceptable',
+      description:
+        'Accept header must allow application/json, application/x-ndjson, text/csv, or application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
   }
 
   const queryParams = { ...req.query };

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ import {
   fetchFDA,
   executeQuery,
   executeQueryStream,
+  executeQueryCsvStream,
   createDA,
   getFDA,
   updateFDA,
@@ -382,13 +383,19 @@ app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
   const servicePath = req.get('Fiware-ServicePath');
   const accept = req.get('Accept') || 'application/json';
   const fresh = parseBooleanQueryParam(req.query.fresh, 'fresh');
-  const rawOutputType = req.query.outputType || DEFAULT_OUTPUT_TYPE;
+  let outputType = 'json';
 
-  if (!VALID_OUTPUT_TYPES.includes(rawOutputType)) {
-    return res.status(400).json({
-      error: 'BadRequest',
-      description: `Invalid outputType '${rawOutputType}'. Allowed values: ${VALID_OUTPUT_TYPES.join(', ')}`,
-    });
+  if (accept.includes('application/x-ndjson')) {
+    outputType = 'ndjson';
+  } else if (accept.includes('text/csv')) {
+    outputType = 'csv';
+  } else if (
+    accept.includes(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ) ||
+    accept.includes('application/vnd.ms-excel')
+  ) {
+    outputType = 'xls';
   }
 
   const queryParams = { ...req.query };
@@ -408,9 +415,20 @@ app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
     ...queryParams,
   };
 
-  // Content negotiation: NDJSON streaming takes precedence over outputType
-  if (accept.includes('application/x-ndjson')) {
+  if (outputType === 'ndjson') {
     return executeQueryStream({
+      service,
+      visibility,
+      servicePath,
+      params,
+      req,
+      res,
+      fresh,
+    });
+  }
+
+  if (outputType === 'csv') {
+    return executeQueryCsvStream({
       service,
       visibility,
       servicePath,
@@ -429,14 +447,7 @@ app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
     fresh,
   });
 
-  if (rawOutputType === 'csv') {
-    const csv = rowsToCsv(rows);
-    res.setHeader('Content-Type', 'text/csv');
-    res.setHeader('Content-Disposition', 'attachment; filename="results.csv"');
-    return res.send(csv);
-  }
-
-  if (rawOutputType === 'xls') {
+  if (outputType === 'xls') {
     const buffer = await rowsToXlsx(rows);
     res.setHeader(
       'Content-Type',

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ const DATA_CONTENT_TYPES = [
   'application/vnd.ms-excel',
 ];
 
-const DATA_CONTENT_TYPE_TO_OUTPUT = {
+const DATA_ACCEPT_CONTENT_TYPE_TO_OUTPUT = {
   'application/json': 'json',
   'application/x-ndjson': 'ndjson',
   'text/csv': 'csv',
@@ -412,7 +412,7 @@ app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
     });
   }
 
-  const outputType = DATA_CONTENT_TYPE_TO_OUTPUT[matched];
+  const outputType = DATA_ACCEPT_CONTENT_TYPE_TO_OUTPUT[matched];
 
   const queryParams = { ...req.query };
   delete queryParams.fresh;

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ import {
 import { handleCdaQuery } from './lib/compat/cdaAdapter.js';
 import {
   validateAllowedFieldsBody,
+  validateForbiddenFieldsQuery,
   parseBooleanQueryParam,
 } from './lib/utils/utils.js';
 import {
@@ -382,8 +383,10 @@ app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
   const service = req.get('Fiware-Service');
   const servicePath = req.get('Fiware-ServicePath');
   const accept = req.get('Accept');
-  const fresh = parseBooleanQueryParam(req.query.fresh, 'fresh');
   let outputType = 'json';
+
+  validateForbiddenFieldsQuery(req.query, ['outputType']);
+  const fresh = parseBooleanQueryParam(req.query.fresh, 'fresh');
 
   if (!accept || accept.trim() === '*/*') {
     outputType = 'json';

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,23 @@ export const app = express();
 const PORT = config.port;
 const logger = getBasicLogger();
 
+// Supported MIME types for /data, listed in server-default preference order.
+const DATA_CONTENT_TYPES = [
+  'application/json',
+  'application/x-ndjson',
+  'text/csv',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel',
+];
+
+const DATA_CONTENT_TYPE_TO_OUTPUT = {
+  'application/json': 'json',
+  'application/x-ndjson': 'ndjson',
+  'text/csv': 'csv',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xls',
+  'application/vnd.ms-excel': 'xls',
+};
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
@@ -382,45 +399,20 @@ app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
   const { visibility, fdaId, daId } = req.params;
   const service = req.get('Fiware-Service');
   const servicePath = req.get('Fiware-ServicePath');
-  const accept = req.get('Accept');
-  let outputType = 'json';
 
   validateForbiddenFieldsQuery(req.query, ['outputType']);
   const fresh = parseBooleanQueryParam(req.query.fresh, 'fresh');
 
-  if (!accept || accept.trim() === '*/*') {
-    outputType = 'json';
-  } else if (
-    accept.includes('application/x-ndjson') &&
-    req.accepts('application/x-ndjson')
-  ) {
-    outputType = 'ndjson';
-  } else if (accept.includes('text/csv') && req.accepts('text/csv')) {
-    outputType = 'csv';
-  } else if (
-    (accept.includes(
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    ) &&
-      req.accepts(
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      )) ||
-    (accept.includes('application/vnd.ms-excel') &&
-      req.accepts('application/vnd.ms-excel'))
-  ) {
-    outputType = 'xls';
-  } else if (
-    accept.includes('application/json') ||
-    accept.includes('application/*') ||
-    accept.includes('*/*')
-  ) {
-    outputType = 'json';
-  } else {
+  const matched = req.accepts(DATA_CONTENT_TYPES);
+  if (!matched) {
     return res.status(406).json({
       error: 'NotAcceptable',
       description:
         'Accept header must allow application/json, application/x-ndjson, text/csv, or application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     });
   }
+
+  const outputType = DATA_CONTENT_TYPE_TO_OUTPUT[matched];
 
   const queryParams = { ...req.query };
   delete queryParams.fresh;

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -632,7 +632,6 @@ function replaceNamedParamsWithPositional(query, params) {
 
   const text = query.replace(/\$([A-Za-z_][A-Za-z0-9_]*)/g, (_m, name) => {
     if (!Object.prototype.hasOwnProperty.call(params, name)) {
-      // c8 reports a false negative on multiline constructor lines in this branch.
       /* c8 ignore next 5 */
       throw new FDAError(
         400,
@@ -1087,7 +1086,6 @@ export async function cleanPartition(
 
   const cutoff = getWindowDate(windowSize);
   if (!cutoff) {
-    // c8 reports a false negative on multiline constructor lines in this branch.
     /* c8 ignore next 5 */
     throw new FDAError(
       400,

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -246,13 +246,11 @@ export async function executeQueryStream({
 
   try {
     const columnNames = stream.columnNames();
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const chunk = await stream.fetchChunk();
-      if (chunk.rowCount === 0) {
-        break;
-      }
-
+    for (
+      let chunk = await stream.fetchChunk();
+      chunk.rowCount > 0;
+      chunk = await stream.fetchChunk()
+    ) {
       const rows = chunk.getRows();
 
       const lines = [];
@@ -360,13 +358,11 @@ export async function executeQueryCsvStream({
       );
     }
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const chunk = await stream.fetchChunk();
-      if (chunk.rowCount === 0) {
-        break;
-      }
-
+    for (
+      let chunk = await stream.fetchChunk();
+      chunk.rowCount > 0;
+      chunk = await stream.fetchChunk()
+    ) {
       const rows = chunk.getRows();
 
       for (const row of rows) {
@@ -445,13 +441,11 @@ async function executeFreshQueryStream({
 
     res.setHeader('Content-Type', 'application/x-ndjson');
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const rows = await cursorReader.readNextChunk();
-      if (rows.length === 0) {
-        break;
-      }
-
+    for (
+      let rows = await cursorReader.readNextChunk();
+      rows.length > 0;
+      rows = await cursorReader.readNextChunk()
+    ) {
       for (const row of rows) {
         const safeObj = normalizeForSerialization(row);
         const ok = res.write(JSON.stringify(safeObj) + '\n');
@@ -513,13 +507,11 @@ async function executeFreshQueryCsvStream({
 
     let columns;
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const rows = await cursorReader.readNextChunk();
-      if (rows.length === 0) {
-        break;
-      }
-
+    for (
+      let rows = await cursorReader.readNextChunk();
+      rows.length > 0;
+      rows = await cursorReader.readNextChunk()
+    ) {
       if (!columns) {
         columns = Object.keys(rows[0]);
         if (columns.length > 0) {

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -56,7 +56,7 @@ import {
   updateFDAStatus,
 } from './utils/mongo.js';
 import {
-  convertBigInt,
+  normalizeForSerialization,
   getWindowDate,
   assertFreshQueriesEnabled,
   acquireFreshQuerySlot,
@@ -75,7 +75,7 @@ const VALID_VISIBILITIES_SET = new Set(VALID_VISIBILITIES);
 const CSV_CONTENT_TYPE = 'text/csv; charset=utf-8';
 
 function stringifyCsvValue(value) {
-  const normalizedValue = convertBigInt(value);
+  const normalizedValue = normalizeForSerialization(value);
 
   if (normalizedValue === null || normalizedValue === undefined) {
     return '';
@@ -264,7 +264,7 @@ export async function executeQueryStream({
           rowObj[columnNames[i]] = row[i];
         }
 
-        const safeObj = convertBigInt(rowObj);
+        const safeObj = normalizeForSerialization(rowObj);
         lines.push(JSON.stringify(safeObj));
       }
 
@@ -397,7 +397,7 @@ async function executeFreshQuery({ service, visibility, servicePath, params }) {
     );
 
     const rows = await runPgQuery(service, text, values);
-    return convertBigInt(rows);
+    return normalizeForSerialization(rows);
   } catch (e) {
     if (e instanceof FDAError) {
       throw e;
@@ -453,7 +453,7 @@ async function executeFreshQueryStream({
       }
 
       for (const row of rows) {
-        const safeObj = convertBigInt(row);
+        const safeObj = normalizeForSerialization(row);
         const ok = res.write(JSON.stringify(safeObj) + '\n');
         if (!ok) {
           await new Promise((resolve) => res.once('drain', resolve));

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -72,6 +72,43 @@ import { FDAError } from './fdaError.js';
 const FRESH_CURSOR_BATCH_SIZE = 250;
 export const VALID_VISIBILITIES = ['public', 'private'];
 const VALID_VISIBILITIES_SET = new Set(VALID_VISIBILITIES);
+const CSV_CONTENT_TYPE = 'text/csv; charset=utf-8';
+
+function stringifyCsvValue(value) {
+  const normalizedValue = convertBigInt(value);
+
+  if (normalizedValue === null || normalizedValue === undefined) {
+    return '';
+  }
+
+  if (typeof normalizedValue === 'object') {
+    return JSON.stringify(normalizedValue);
+  }
+
+  return String(normalizedValue);
+}
+
+function escapeCsvValue(value) {
+  const strValue = stringifyCsvValue(value);
+
+  if (
+    strValue.includes(',') ||
+    strValue.includes('"') ||
+    strValue.includes('\n') ||
+    strValue.includes('\r')
+  ) {
+    return '"' + strValue.replace(/"/g, '""') + '"';
+  }
+
+  return strValue;
+}
+
+async function writeCsvLine(res, line) {
+  const ok = res.write(line);
+  if (!ok) {
+    await new Promise((resolve) => res.once('drain', resolve));
+  }
+}
 
 export async function getFDAs(service, visibility, servicePath) {
   const fdas = await retrieveFDAs(service);
@@ -245,6 +282,106 @@ export async function executeQueryStream({
   return res.end();
 }
 
+export async function executeQueryCsvStream({
+  service,
+  visibility,
+  servicePath,
+  params,
+  req,
+  res,
+  fresh = false,
+}) {
+  if (fresh) {
+    return executeFreshQueryCsvStream({
+      service,
+      visibility,
+      servicePath,
+      params,
+      req,
+      res,
+    });
+  }
+
+  const { fdaId, daId, ...rest } = params;
+
+  await ensureFDAReadyForQuery(service, fdaId, visibility, servicePath);
+
+  const conn = await getDBConnection();
+
+  let stream;
+  let close;
+
+  try {
+    const result = await runPreparedStatementStream(
+      conn,
+      service,
+      fdaId,
+      daId,
+      rest,
+      servicePath,
+    );
+
+    stream = result.stream;
+    close = result.close;
+  } catch (err) {
+    await releaseDBConnection(conn);
+    throw err;
+  }
+
+  let cleaned = false;
+
+  const cleanup = async () => {
+    if (cleaned) {
+      return;
+    }
+    cleaned = true;
+
+    try {
+      await close();
+    } finally {
+      await releaseDBConnection(conn);
+    }
+  };
+
+  req.on('close', () => {
+    cleanup().catch(() => {});
+  });
+
+  res.setHeader('Content-Type', CSV_CONTENT_TYPE);
+  res.setHeader('Content-Disposition', 'attachment; filename="results.csv"');
+
+  try {
+    const columnNames = stream.columnNames();
+    if (columnNames.length > 0) {
+      await writeCsvLine(
+        res,
+        columnNames.map((columnName) => escapeCsvValue(columnName)).join(',') +
+          '\n',
+      );
+    }
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const chunk = await stream.fetchChunk();
+      if (chunk.rowCount === 0) {
+        break;
+      }
+
+      const rows = chunk.getRows();
+
+      for (const row of rows) {
+        const csvLine =
+          row.map((cell) => escapeCsvValue(cell)).join(',') + '\n';
+        await writeCsvLine(res, csvLine);
+      }
+    }
+  } finally {
+    await cleanup();
+  }
+
+  return res.end();
+}
+
 async function executeFreshQuery({ service, visibility, servicePath, params }) {
   assertFreshQueriesEnabled(config.roles.syncQueries);
 
@@ -321,6 +458,83 @@ async function executeFreshQueryStream({
         if (!ok) {
           await new Promise((resolve) => res.once('drain', resolve));
         }
+      }
+    }
+  } catch (e) {
+    if (e instanceof FDAError) {
+      throw e;
+    }
+
+    throw e;
+  } finally {
+    await cursorReader?.close();
+    releaseFreshSlot();
+  }
+
+  return res.end();
+}
+
+async function executeFreshQueryCsvStream({
+  service,
+  visibility,
+  servicePath,
+  params,
+  req,
+  res,
+}) {
+  assertFreshQueriesEnabled(config.roles.syncQueries);
+
+  const releaseFreshSlot = acquireFreshQuerySlot(
+    config.freshQueries.maxConcurrent,
+  );
+  let cursorReader;
+
+  try {
+    const { text, values } = await buildFreshQueryStatement(
+      service,
+      visibility,
+      servicePath,
+      params,
+    );
+
+    cursorReader = await createPgCursorReader(
+      service,
+      text,
+      values,
+      FRESH_CURSOR_BATCH_SIZE,
+    );
+
+    req.on('close', () => {
+      cursorReader?.close().catch(() => {});
+    });
+
+    res.setHeader('Content-Type', CSV_CONTENT_TYPE);
+    res.setHeader('Content-Disposition', 'attachment; filename="results.csv"');
+
+    let columns;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const rows = await cursorReader.readNextChunk();
+      if (rows.length === 0) {
+        break;
+      }
+
+      if (!columns) {
+        columns = Object.keys(rows[0]);
+        if (columns.length > 0) {
+          await writeCsvLine(
+            res,
+            columns.map((columnName) => escapeCsvValue(columnName)).join(',') +
+              '\n',
+          );
+        }
+      }
+
+      for (const row of rows) {
+        const csvLine =
+          columns.map((column) => escapeCsvValue(row[column])).join(',') + '\n';
+        await writeCsvLine(res, csvLine);
       }
     }
   } catch (e) {

--- a/src/lib/utils/pg.js
+++ b/src/lib/utils/pg.js
@@ -32,6 +32,9 @@ import { FDAError } from '../fdaError.js';
 import { getBasicLogger } from './logger.js';
 
 const { Client, Pool } = pg;
+pg.types.setTypeParser(pg.types.builtins.INT8, (value) =>
+  value === null ? null : BigInt(value),
+);
 const logger = getBasicLogger();
 const pools = new Map();
 

--- a/src/lib/utils/utils.js
+++ b/src/lib/utils/utils.js
@@ -26,8 +26,8 @@ import { FDAError } from '../fdaError.js';
 
 let activeFreshQueries = 0;
 
-// Convert BigInt values to numbers for JSON serialization
-export function convertBigInt(obj) {
+// Normalize runtime values so downstream serializers emit stable output.
+export function normalizeForSerialization(obj) {
   if (typeof obj === 'bigint') {
     return Number(obj);
   }
@@ -35,12 +35,12 @@ export function convertBigInt(obj) {
     return obj.toISOString();
   }
   if (Array.isArray(obj)) {
-    return obj.map(convertBigInt);
+    return obj.map(normalizeForSerialization);
   }
   if (obj !== null && typeof obj === 'object') {
     const converted = {};
     for (const key in obj) {
-      converted[key] = convertBigInt(obj[key]);
+      converted[key] = normalizeForSerialization(obj[key]);
     }
     return converted;
   }

--- a/src/lib/utils/utils.js
+++ b/src/lib/utils/utils.js
@@ -59,6 +59,19 @@ export function validateAllowedFieldsBody(body, allowedFields) {
   }
 }
 
+export function validateForbiddenFieldsQuery(query, forbiddenFields) {
+  const keys = Object.keys(query);
+  const invalid = keys.filter((k) => forbiddenFields.includes(k));
+  if (invalid.length > 0) {
+    const err = new Error(
+      'Invalid fields in request query, check your request',
+    );
+    err.status = 400;
+    err.type = 'BadRequest';
+    throw err;
+  }
+}
+
 export function parseBooleanQueryParam(value, name) {
   if (value === undefined) {
     return false;

--- a/src/lib/utils/utils.js
+++ b/src/lib/utils/utils.js
@@ -31,6 +31,9 @@ export function convertBigInt(obj) {
   if (typeof obj === 'bigint') {
     return Number(obj);
   }
+  if (obj instanceof Date) {
+    return obj.toISOString();
+  }
   if (Array.isArray(obj)) {
     return obj.map(convertBigInt);
   }

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -1779,8 +1779,8 @@ export function runFDAIntegrationSuite({ mode, label }) {
     });
 
     test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data serializes date consistently for fresh CSV/NDJSON and keeps numeric types in NDJSON', async () => {
-      const fdaSerializationId = 'fda_fresh_serialization_issue137';
-      const daSerializationId = 'da_fresh_serialization_issue137';
+      const fdaSerializationId = 'fda_serialization_regression';
+      const daSerializationId = 'da_serialization_regression';
 
       const createFda = await httpReq({
         method: 'POST',
@@ -2378,8 +2378,8 @@ export function runFDAIntegrationSuite({ mode, label }) {
     });
 
     test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data returns CSV when Accept: text/csv', async () => {
-      const fdaCsvId = `fda_accept_csv_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
-      const daCsvId = `da_accept_csv_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+      const fdaCsvId = 'fda_accept_csv';
+      const daCsvId = 'da_accept_csv';
 
       const createFda = await httpReq({
         method: 'POST',
@@ -2429,7 +2429,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (res.status >= 400) {
         console.error(
-          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data outputType=csv failed:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data Accept=text/csv failed:',
           res.status,
           res.text,
         );
@@ -2449,8 +2449,8 @@ export function runFDAIntegrationSuite({ mode, label }) {
     });
 
     test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data returns XLSX when Accept requests spreadsheet mime', async () => {
-      const fdaXlsId = `fda_accept_xls_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
-      const daXlsId = `da_accept_xls_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+      const fdaXlsId = 'fda_accept_xls';
+      const daXlsId = 'da_accept_xls';
 
       const createFda = await httpReq({
         method: 'POST',
@@ -2501,7 +2501,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (res.status >= 400) {
         console.error(
-          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data outputType=xls failed:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data Accept=xlsx failed:',
           res.status,
           res.text,
         );
@@ -2519,9 +2519,9 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(res.buffer.length).toBeGreaterThan(100);
     });
 
-    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data ignores outputType and defaults to JSON when Accept is generic', async () => {
-      const fdaJsonId = `fda_accept_json_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
-      const daJsonId = `da_accept_json_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data rejects outputType query param', async () => {
+      const fdaJsonId = 'fda_accept_json';
+      const daJsonId = 'da_accept_json';
 
       const createFda = await httpReq({
         method: 'POST',
@@ -2567,12 +2567,30 @@ export function runFDAIntegrationSuite({ mode, label }) {
         headers: { 'Fiware-Service': service },
       });
 
-      expect(res.status).toBe(200);
-      expect(Array.isArray(res.json)).toBe(true);
-      expect(res.json).toEqual([
-        { id: '1', name: 'ana', age: '30' },
-        { id: '3', name: 'carlos', age: '40' },
-      ]);
+      expect(res.status).toBe(400);
+      expect(res.json.error).toBe('BadRequest');
+      expect(res.json.description).toContain(
+        'Query param "outputType" is no longer supported.',
+      );
+    });
+
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data returns 406 for unsupported Accept header', async () => {
+      const res = await httpReq({
+        method: 'GET',
+        url: buildDaDataUrl(baseUrl, servicePath, fdaId, daId, {
+          minAge: 25,
+        }),
+        headers: {
+          'Fiware-Service': service,
+          Accept: 'video/mpg4',
+        },
+      });
+
+      expect(res.status).toBe(406);
+      expect(res.json.error).toBe('NotAcceptable');
+      expect(res.json.description).toContain(
+        'Accept header must allow application/json',
+      );
     });
 
     test('GET /{visibility}/... returns 400 for an invalid visibility value', async () => {

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -1778,6 +1778,125 @@ export function runFDAIntegrationSuite({ mode, label }) {
       }
     });
 
+    test('GET /query serializes date consistently for fresh CSV/NDJSON and keeps numeric types in NDJSON', async () => {
+      const fdaSerializationId = 'fda_fresh_serialization_issue137';
+      const daSerializationId = 'da_fresh_serialization_issue137';
+
+      const createFda = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas`,
+        headers: {
+          'Fiware-Service': service,
+          'Fiware-ServicePath': servicePath,
+        },
+        body: {
+          id: fdaSerializationId,
+          description: 'issue 137 serialization regression fda',
+          query: `
+            SELECT
+              id,
+              timeinstant AS date,
+              EXTRACT(DAY FROM timeinstant)::INT AS day,
+              COUNT(*) OVER() AS countperperiod
+            FROM public.users
+            ORDER BY id
+          `,
+        },
+      });
+
+      expect(createFda.status).toBe(202);
+
+      await waitUntilFDACompleted({
+        baseUrl,
+        service,
+        fdaId: fdaSerializationId,
+      });
+
+      const createDa = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas/${fdaSerializationId}/das`,
+        headers: { 'Fiware-Service': service },
+        body: {
+          id: daSerializationId,
+          description: 'issue 137 serialization regression da',
+          query: `
+            SELECT date, day, countperperiod
+            ORDER BY day, date
+          `,
+        },
+      });
+
+      expect(createDa.status).toBe(201);
+
+      const cachedCsv = await httpReqRaw({
+        method: 'GET',
+        url: buildDaDataUrl(
+          baseUrl,
+          servicePath,
+          fdaSerializationId,
+          daSerializationId,
+        ),
+        headers: {
+          'Fiware-Service': service,
+          Accept: 'text/csv',
+        },
+      });
+
+      expect(cachedCsv.status).toBe(200);
+      expect(cachedCsv.headers['content-type']).toContain('text/csv');
+      expect(cachedCsv.text).not.toContain('[object Object]');
+
+      const freshCsv = await httpReqRaw({
+        method: 'GET',
+        url: buildDaDataUrl(
+          baseUrl,
+          servicePath,
+          fdaSerializationId,
+          daSerializationId,
+          { fresh: true },
+        ),
+        headers: {
+          'Fiware-Service': service,
+          Accept: 'text/csv',
+        },
+      });
+
+      expect(freshCsv.status).toBe(200);
+      expect(freshCsv.headers['content-type']).toContain('text/csv');
+      expect(freshCsv.text).not.toContain('[object Object]');
+
+      const freshNdjson = await httpReqRaw({
+        method: 'GET',
+        url: buildDaDataUrl(
+          baseUrl,
+          servicePath,
+          fdaSerializationId,
+          daSerializationId,
+          { fresh: true },
+        ),
+        headers: {
+          'Fiware-Service': service,
+          Accept: 'application/x-ndjson',
+        },
+      });
+
+      expect(freshNdjson.status).toBe(200);
+      expect(freshNdjson.headers['content-type']).toContain(
+        'application/x-ndjson',
+      );
+
+      const rows = freshNdjson.text
+        .split('\n')
+        .filter((line) => line.trim())
+        .map((line) => JSON.parse(line));
+
+      expect(rows.length).toBeGreaterThan(0);
+      expect(typeof rows[0].date).toBe('string');
+      expect(rows[0].date).not.toEqual({});
+      expect(rows[0].date).toContain('T');
+      expect(typeof rows[0].countperperiod).toBe('number');
+    });
+
     test('GET /query rejects invalid fresh query param', async () => {
       const res = await httpReq({
         method: 'GET',
@@ -2258,14 +2377,54 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(row2).toEqual({ id: 3, name: 'carlos', age: 40 });
     });
 
-    test('GET /query supports outputType=csv', async () => {
+    test('GET /query returns CSV when Accept: text/csv', async () => {
+      const fdaCsvId = `fda_accept_csv_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+      const daCsvId = `da_accept_csv_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+
+      const createFda = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas`,
+        headers: {
+          'Fiware-Service': service,
+          'Fiware-ServicePath': servicePath,
+        },
+        body: {
+          id: fdaCsvId,
+          query: 'SELECT id, name, age FROM public.users ORDER BY id',
+          description: 'accept csv fixture',
+        },
+      });
+
+      expect(createFda.status).toBe(202);
+      await waitUntilFDACompleted({ baseUrl, service, fdaId: fdaCsvId });
+
+      const createDa = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas/${fdaCsvId}/das`,
+        headers: { 'Fiware-Service': service },
+        body: {
+          id: daCsvId,
+          description: 'accept csv da fixture',
+          query: `
+            SELECT id, name, age
+            WHERE age > $minAge
+            ORDER BY id
+          `,
+          params: [{ name: 'minAge', type: 'Number', required: true }],
+        },
+      });
+
+      expect(createDa.status).toBe(201);
+
       const res = await httpReqRaw({
         method: 'GET',
-        url: buildDaDataUrl(baseUrl, servicePath, fdaId, daId, {
+        url: buildDaDataUrl(baseUrl, servicePath, fdaCsvId, daCsvId, {
           minAge: 25,
-          outputType: 'csv',
         }),
-        headers: { 'Fiware-Service': service },
+        headers: {
+          'Fiware-Service': service,
+          Accept: 'text/csv',
+        },
       });
 
       if (res.status >= 400) {
@@ -2289,14 +2448,55 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(lines[2]).toBe('3,carlos,40');
     });
 
-    test('GET /query supports outputType=xls', async () => {
+    test('GET /query returns XLSX when Accept requests spreadsheet mime', async () => {
+      const fdaXlsId = `fda_accept_xls_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+      const daXlsId = `da_accept_xls_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+
+      const createFda = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas`,
+        headers: {
+          'Fiware-Service': service,
+          'Fiware-ServicePath': servicePath,
+        },
+        body: {
+          id: fdaXlsId,
+          query: 'SELECT id, name, age FROM public.users ORDER BY id',
+          description: 'accept xls fixture',
+        },
+      });
+
+      expect(createFda.status).toBe(202);
+      await waitUntilFDACompleted({ baseUrl, service, fdaId: fdaXlsId });
+
+      const createDa = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas/${fdaXlsId}/das`,
+        headers: { 'Fiware-Service': service },
+        body: {
+          id: daXlsId,
+          description: 'accept xls da fixture',
+          query: `
+            SELECT id, name, age
+            WHERE age > $minAge
+            ORDER BY id
+          `,
+          params: [{ name: 'minAge', type: 'Number', required: true }],
+        },
+      });
+
+      expect(createDa.status).toBe(201);
+
       const res = await httpReqRaw({
         method: 'GET',
-        url: buildDaDataUrl(baseUrl, servicePath, fdaId, daId, {
+        url: buildDaDataUrl(baseUrl, servicePath, fdaXlsId, daXlsId, {
           minAge: 25,
-          outputType: 'xls',
         }),
-        headers: { 'Fiware-Service': service },
+        headers: {
+          'Fiware-Service': service,
+          Accept:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        },
       });
 
       if (res.status >= 400) {
@@ -2319,19 +2519,60 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(res.buffer.length).toBeGreaterThan(100);
     });
 
-    test('GET /query rejects unsupported outputType', async () => {
+    test('GET /query ignores outputType and defaults to JSON when Accept is generic', async () => {
+      const fdaJsonId = `fda_accept_json_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+      const daJsonId = `da_accept_json_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+
+      const createFda = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas`,
+        headers: {
+          'Fiware-Service': service,
+          'Fiware-ServicePath': servicePath,
+        },
+        body: {
+          id: fdaJsonId,
+          query: 'SELECT id, name, age FROM public.users ORDER BY id',
+          description: 'accept json fixture',
+        },
+      });
+
+      expect(createFda.status).toBe(202);
+      await waitUntilFDACompleted({ baseUrl, service, fdaId: fdaJsonId });
+
+      const createDa = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas/${fdaJsonId}/das`,
+        headers: { 'Fiware-Service': service },
+        body: {
+          id: daJsonId,
+          description: 'accept json da fixture',
+          query: `
+            SELECT id, name, age
+            WHERE age > $minAge
+            ORDER BY id
+          `,
+          params: [{ name: 'minAge', type: 'Number', required: true }],
+        },
+      });
+
+      expect(createDa.status).toBe(201);
+
       const res = await httpReq({
         method: 'GET',
-        url: buildDaDataUrl(baseUrl, servicePath, fdaId, daId, {
+        url: buildDaDataUrl(baseUrl, servicePath, fdaJsonId, daJsonId, {
           minAge: 25,
           outputType: 'html',
         }),
         headers: { 'Fiware-Service': service },
       });
 
-      expect(res.status).toBe(400);
-      expect(res.json.error).toBe('BadRequest');
-      expect(res.json.description).toContain('Invalid outputType');
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.json)).toBe(true);
+      expect(res.json).toEqual([
+        { id: '1', name: 'ana', age: '30' },
+        { id: '3', name: 'carlos', age: '40' },
+      ]);
     });
 
     test('GET /{visibility}/... returns 400 for an invalid visibility value', async () => {

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -493,8 +493,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
     async function waitForApiReady() {
       const start = Date.now();
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
+      while (Date.now() - start <= 30000) {
         try {
           const res = await httpReq({
             method: 'GET',
@@ -506,11 +505,10 @@ export function runFDAIntegrationSuite({ mode, label }) {
         } catch {
           // ignore, server not up yet
         }
-        if (Date.now() - start > 30000) {
-          throw new Error('Timeout waiting API to start');
-        }
         await wait(200);
       }
+
+      throw new Error('Timeout waiting API to start');
     }
 
     async function startApp() {

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -922,7 +922,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       });
     });
 
-    test('POST /fdas pending allows DA creation but rejects /query until first completion', async () => {
+    test('POST /fdas pending allows DA creation but rejects GET /{visibility}/fdas/{fdaId}/das/{daId}/data until first completion', async () => {
       const pendingFdaId = 'fda_pending_first_fetch';
       const pendingDaId = 'da_pending_first_fetch';
 
@@ -978,7 +978,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (queryRes.status >= 400) {
         console.error(
-          'GET /query failed as expected while FDA is pending:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data failed as expected while FDA is pending:',
           queryRes.status,
           queryRes.json ?? queryRes.text,
         );
@@ -1024,7 +1024,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(res.json.some((x) => x.id === fdaId)).toBe(true);
     });
 
-    test('POST /fdas/:fdaId/das + GET /query executes DuckDB against Parquet', async () => {
+    test('POST /fdas/:fdaId/das + GET /{visibility}/fdas/{fdaId}/das/{daId}/data executes DuckDB against Parquet', async () => {
       // DuckDB reads parquet generated in  s3://<bucket>/<fdaID>.parquet
       const daQuery = `
       SELECT id, name, age
@@ -1069,7 +1069,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (queryRes.status >= 400) {
         console.error(
-          'GET /query failed:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data failed:',
           queryRes.status,
           queryRes.json ?? queryRes.text,
         );
@@ -1298,7 +1298,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(enumUpdateRes.status).toBe(400);
     });
 
-    test('GET /query returns JSON array when Accept: application/json', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data returns JSON array when Accept: application/json', async () => {
       const res = await httpReq({
         method: 'GET',
         url: buildDaDataUrl(baseUrl, servicePath, fdaId, daId, {
@@ -1309,7 +1309,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (res.status >= 400) {
         console.error(
-          'GET /query (json) failed:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data (json) failed:',
           res.status,
           res.json ?? res.text,
         );
@@ -1321,7 +1321,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       ]);
     });
 
-    test('GET /query with fresh=true runs query against PostgreSQL source', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data with fresh=true runs query against PostgreSQL source', async () => {
       const daFreshId = 'da_fresh_users';
 
       const createDa = await httpReq({
@@ -1401,7 +1401,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       }
     });
 
-    test('GET /query with fresh=true supports default Boolean and DateTime params', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data with fresh=true supports default Boolean and DateTime params', async () => {
       const fdaFreshDefaultsId = 'fda_fresh_defaults';
       const daFreshDefaultsId = 'da_fresh_defaults';
 
@@ -1473,7 +1473,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (freshRes.status >= 400) {
         console.error(
-          'GET /query fresh defaults failed:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data fresh defaults failed:',
           freshRes.status,
           freshRes.json ?? freshRes.text,
         );
@@ -1541,7 +1541,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       );
     });
 
-    test('GET /query with fresh=true returns 429 when max concurrent fresh queries is reached', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data with fresh=true returns 429 when max concurrent fresh queries is reached', async () => {
       const fdaFreshLimitId = 'fda_fresh_limit';
       const daFreshLimitId = 'da_fresh_limit';
 
@@ -1633,7 +1633,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(firstFreshRes.status).toBe(200);
     });
 
-    test('GET /query with fresh=true streams NDJSON progressively from PostgreSQL (real streaming)', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data with fresh=true streams NDJSON progressively from PostgreSQL (real streaming)', async () => {
       const fdaFreshStreamId = 'fda_fresh_stream_real';
       const daFreshStreamId = 'da_fresh_stream_real';
 
@@ -1778,7 +1778,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       }
     });
 
-    test('GET /query serializes date consistently for fresh CSV/NDJSON and keeps numeric types in NDJSON', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data serializes date consistently for fresh CSV/NDJSON and keeps numeric types in NDJSON', async () => {
       const fdaSerializationId = 'fda_fresh_serialization_issue137';
       const daSerializationId = 'da_fresh_serialization_issue137';
 
@@ -1897,7 +1897,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(typeof rows[0].countperperiod).toBe('number');
     });
 
-    test('GET /query rejects invalid fresh query param', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data rejects invalid fresh query param', async () => {
       const res = await httpReq({
         method: 'GET',
         url: buildDaDataUrl(baseUrl, servicePath, fdaId, daId, {
@@ -1911,7 +1911,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(res.json.error).toBe('BadRequest');
     });
 
-    test('POST /fdas/:fdaId/das + GET /query using default params', async () => {
+    test('POST /fdas/:fdaId/das + GET /{visibility}/fdas/{fdaId}/das/{daId}/data using default params', async () => {
       // DuckDB reads parquet generated in  s3://<bucket>/<fdaID>.parquet
       const daQuery = `
       SELECT id, name, age
@@ -2176,7 +2176,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (enumQueryRes.status >= 400) {
         console.error(
-          'GET /query failed as expected:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data failed as expected:',
           enumQueryRes.status,
           enumQueryRes.json ?? enumQueryRes.text,
         );
@@ -2195,7 +2195,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (rangeQueryRes.status >= 400) {
         console.error(
-          'GET /query failed as expected:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data failed as expected:',
           rangeQueryRes.status,
           rangeQueryRes.json ?? rangeQueryRes.text,
         );
@@ -2213,7 +2213,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (defaultsQueryRes.status >= 400) {
         console.error(
-          'GET /query failed:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data failed:',
           defaultsQueryRes.status,
           defaultsQueryRes.json ?? defaultsQueryRes.text,
         );
@@ -2234,7 +2234,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (requiredQueryRes.status >= 400) {
         console.error(
-          'GET /query failed as expected:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data failed as expected:',
           requiredQueryRes.status,
           requiredQueryRes.json ?? requiredQueryRes.text,
         );
@@ -2253,7 +2253,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (typeQueryRes.status >= 400) {
         console.error(
-          'GET /query failed as expected:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data failed as expected:',
           typeQueryRes.status,
           typeQueryRes.json ?? typeQueryRes.text,
         );
@@ -2272,7 +2272,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (dateQueryRes.status >= 400) {
         console.error(
-          'GET /query failed as expected:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data failed as expected:',
           dateQueryRes.status,
           dateQueryRes.json ?? dateQueryRes.text,
         );
@@ -2291,7 +2291,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (boolQueryRes.status >= 400) {
         console.error(
-          'GET /query failed as expected:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data failed as expected:',
           boolQueryRes.status,
           boolQueryRes.json ?? boolQueryRes.text,
         );
@@ -2344,7 +2344,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       ]);
     });
 
-    test('GET /query returns NDJSON when Accept: application/x-ndjson', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data returns NDJSON when Accept: application/x-ndjson', async () => {
       const queryRes = await httpReq({
         method: 'GET',
         url: buildDaDataUrl(baseUrl, servicePath, fdaId, daId, {
@@ -2358,7 +2358,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (queryRes.status >= 400) {
         console.error(
-          'GET /query NDJSON failed:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data NDJSON failed:',
           queryRes.status,
           queryRes.text,
         );
@@ -2377,7 +2377,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(row2).toEqual({ id: 3, name: 'carlos', age: 40 });
     });
 
-    test('GET /query returns CSV when Accept: text/csv', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data returns CSV when Accept: text/csv', async () => {
       const fdaCsvId = `fda_accept_csv_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
       const daCsvId = `da_accept_csv_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
 
@@ -2429,7 +2429,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (res.status >= 400) {
         console.error(
-          'GET /query outputType=csv failed:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data outputType=csv failed:',
           res.status,
           res.text,
         );
@@ -2448,7 +2448,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(lines[2]).toBe('3,carlos,40');
     });
 
-    test('GET /query returns XLSX when Accept requests spreadsheet mime', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data returns XLSX when Accept requests spreadsheet mime', async () => {
       const fdaXlsId = `fda_accept_xls_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
       const daXlsId = `da_accept_xls_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
 
@@ -2501,7 +2501,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       if (res.status >= 400) {
         console.error(
-          'GET /query outputType=xls failed:',
+          'GET /{visibility}/fdas/{fdaId}/das/{daId}/data outputType=xls failed:',
           res.status,
           res.text,
         );
@@ -2519,7 +2519,7 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(res.buffer.length).toBeGreaterThan(100);
     });
 
-    test('GET /query ignores outputType and defaults to JSON when Accept is generic', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data ignores outputType and defaults to JSON when Accept is generic', async () => {
       const fdaJsonId = `fda_accept_json_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
       const daJsonId = `da_accept_json_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
 

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -2569,8 +2569,8 @@ export function runFDAIntegrationSuite({ mode, label }) {
 
       expect(res.status).toBe(400);
       expect(res.json.error).toBe('BadRequest');
-      expect(res.json.description).toContain(
-        'Query param "outputType" is no longer supported.',
+      expect(res.json.description).toBe(
+        'Invalid fields in request query, check your request',
       );
     });
 

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -1224,6 +1224,22 @@ describe('getFDA', () => {
     );
     expect(result).toEqual({ query: 'SELECT 1', status: 'completed' });
   });
+
+  test('throws FDANotFound when visibility is undefined and FDA does not exist', async () => {
+    mongoMocks.retrieveFDA.mockResolvedValue(null);
+
+    await expect(
+      getFDA('svc', 'fdaA', undefined, '/public'),
+    ).rejects.toMatchObject({
+      status: 404,
+      type: 'FDANotFound',
+    });
+    expect(mongoMocks.retrieveFDA).toHaveBeenCalledWith(
+      'svc',
+      'fdaA',
+      '/public',
+    );
+  });
 });
 
 describe('cleanPartition', () => {

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -464,6 +464,116 @@ describe('fda fresh query execution', () => {
     expect(res.end).toHaveBeenCalledTimes(1);
   });
 
+  test('serializes null and undefined as empty fields in CSV stream', async () => {
+    const { req, res } = createReqRes();
+    const conn = {};
+    const stream = {
+      columnNames: jest.fn().mockReturnValue(['a', 'b', 'c']),
+      fetchChunk: jest
+        .fn()
+        .mockResolvedValueOnce({
+          rowCount: 1,
+          getRows: () => [[null, undefined, 1n]],
+        })
+        .mockResolvedValueOnce({ rowCount: 0, getRows: () => [] }),
+    };
+    const close = jest.fn().mockResolvedValue(undefined);
+
+    dbMocks.getDBConnection.mockResolvedValue(conn);
+    dbMocks.runPreparedStatementStream.mockResolvedValue({ stream, close });
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      status: 'completed',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      lastFetch: new Date('2026-04-08T00:00:00.000Z').toISOString(),
+    });
+
+    await executeQueryCsvStream({
+      service: 'svc',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      params: { fdaId: 'fdaA', daId: 'daA' },
+      req,
+      res,
+      fresh: false,
+    });
+
+    expect(res.write).toHaveBeenNthCalledWith(1, 'a,b,c\n');
+    expect(res.write).toHaveBeenNthCalledWith(2, ',,1\n');
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(dbMocks.releaseDBConnection).toHaveBeenCalledWith(conn);
+  });
+
+  test('escapes CSV values and waits for drain when write returns false', async () => {
+    const { req, res } = createReqRes();
+    const conn = {};
+    const stream = {
+      columnNames: jest.fn().mockReturnValue(['txt']),
+      fetchChunk: jest
+        .fn()
+        .mockResolvedValueOnce({
+          rowCount: 1,
+          getRows: () => [['a,b"c']],
+        })
+        .mockResolvedValueOnce({ rowCount: 0, getRows: () => [] }),
+    };
+    const close = jest.fn().mockResolvedValue(undefined);
+
+    res.write.mockReturnValueOnce(false).mockReturnValue(true);
+    dbMocks.getDBConnection.mockResolvedValue(conn);
+    dbMocks.runPreparedStatementStream.mockResolvedValue({ stream, close });
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      status: 'completed',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      lastFetch: new Date('2026-04-08T00:00:00.000Z').toISOString(),
+    });
+
+    await executeQueryCsvStream({
+      service: 'svc',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      params: { fdaId: 'fdaA', daId: 'daA' },
+      req,
+      res,
+      fresh: false,
+    });
+
+    expect(res.once).toHaveBeenCalledWith('drain', expect.any(Function));
+    expect(res.write).toHaveBeenNthCalledWith(2, '"a,b""c"\n');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  test('releases DB connection if stream initialization fails in CSV mode', async () => {
+    const { req, res } = createReqRes();
+    const conn = {};
+
+    dbMocks.getDBConnection.mockResolvedValue(conn);
+    dbMocks.runPreparedStatementStream.mockRejectedValue(
+      new Error('stream init failed'),
+    );
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      status: 'completed',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      lastFetch: new Date('2026-04-08T00:00:00.000Z').toISOString(),
+    });
+
+    await expect(
+      executeQueryCsvStream({
+        service: 'svc',
+        visibility: 'private',
+        servicePath: '/servicepath',
+        params: { fdaId: 'fdaA', daId: 'daA' },
+        req,
+        res,
+        fresh: false,
+      }),
+    ).rejects.toThrow('stream init failed');
+
+    expect(dbMocks.releaseDBConnection).toHaveBeenCalledWith(conn);
+  });
+
   test('closes cursor when request close event is triggered', async () => {
     const { req, res, reqHandlers } = createReqRes();
     const cursorReader = {
@@ -903,6 +1013,23 @@ describe('deleteFDA', () => {
 
     expect(awsMocks.getS3Client).not.toHaveBeenCalled();
   });
+
+  test('throws FDANotFound when service is missing even if FDA exists', async () => {
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      _id: 'mongo-id',
+      visibility: 'private',
+      servicePath: '/servicepath',
+    });
+
+    await expect(
+      deleteFDA('', 'fdaA', 'private', '/servicepath'),
+    ).rejects.toMatchObject({
+      status: 404,
+      type: 'FDANotFound',
+    });
+
+    expect(awsMocks.getS3Client).not.toHaveBeenCalled();
+  });
 });
 
 describe('DA access and update helpers', () => {
@@ -1240,6 +1367,27 @@ describe('getFDA', () => {
       '/public',
     );
   });
+
+  test('returns accessible FDA when visibility is provided', async () => {
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      _id: 'mongo1',
+      fdaId: 'fdaA',
+      service: 'svc',
+      servicePath: '/public',
+      visibility: 'public',
+      query: 'SELECT 9',
+      status: 'completed',
+    });
+
+    const result = await getFDA('svc', 'fdaA', 'public', '/public');
+
+    expect(mongoMocks.retrieveFDA).toHaveBeenCalledWith(
+      'svc',
+      'fdaA',
+      '/public',
+    );
+    expect(result).toEqual({ query: 'SELECT 9', status: 'completed' });
+  });
 });
 
 describe('cleanPartition', () => {
@@ -1293,6 +1441,15 @@ describe('cleanPartition', () => {
   test('throws CleaningError when FDA is not partitioned', async () => {
     await expect(
       cleanPartition('svc', 'fdaA', 'month', {}, '/public'),
+    ).rejects.toMatchObject({
+      status: 400,
+      type: 'CleaningError',
+    });
+  });
+
+  test('throws CleaningError when partition config is undefined', async () => {
+    await expect(
+      cleanPartition('svc', 'fdaA', 'month', undefined, '/public'),
     ).rejects.toMatchObject({
       status: 400,
       type: 'CleaningError',

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -133,6 +133,7 @@ await jest.unstable_mockModule('../../src/lib/fdaConfig.js', () => ({
 const {
   executeQuery,
   executeQueryStream,
+  executeQueryCsvStream,
   fetchFDA,
   getFDA,
   updateFDA,
@@ -396,6 +397,70 @@ describe('fda fresh query execution', () => {
     expect(res.write).toHaveBeenCalledWith('{"total":12}\n');
     expect(res.once).toHaveBeenCalledWith('drain', expect.any(Function));
     expect(cursorReader.close).toHaveBeenCalledTimes(1);
+    expect(res.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('serializes Date values as ISO strings in fresh NDJSON stream', async () => {
+    const { req, res } = createReqRes();
+    const cursorReader = {
+      readNextChunk: jest
+        .fn()
+        .mockResolvedValueOnce([
+          { date: new Date('2026-04-08T10:11:12.000Z'), count: 1n },
+        ])
+        .mockResolvedValueOnce([]),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+    pgMocks.createPgCursorReader.mockResolvedValue(cursorReader);
+
+    await executeQueryStream({
+      service: 'svc',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      params: { fdaId: 'fdaA', daId: 'daA', id: 1 },
+      req,
+      res,
+      fresh: true,
+    });
+
+    expect(res.write).toHaveBeenCalledWith(
+      '{"date":"2026-04-08T10:11:12.000Z","count":1}\n',
+    );
+    expect(res.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('streams CSV rows in fresh mode', async () => {
+    const { req, res } = createReqRes();
+    const cursorReader = {
+      readNextChunk: jest
+        .fn()
+        .mockResolvedValueOnce([
+          { date: new Date('2026-04-08T10:11:12.000Z'), count: 1n },
+        ])
+        .mockResolvedValueOnce([]),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+    pgMocks.createPgCursorReader.mockResolvedValue(cursorReader);
+
+    await executeQueryCsvStream({
+      service: 'svc',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      params: { fdaId: 'fdaA', daId: 'daA', id: 1 },
+      req,
+      res,
+      fresh: true,
+    });
+
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'text/csv; charset=utf-8',
+    );
+    expect(res.write).toHaveBeenNthCalledWith(1, 'date,count\n');
+    expect(res.write).toHaveBeenNthCalledWith(
+      2,
+      '2026-04-08T10:11:12.000Z,1\n',
+    );
     expect(res.end).toHaveBeenCalledTimes(1);
   });
 

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -1368,6 +1368,25 @@ describe('getFDA', () => {
     );
   });
 
+  test('throws exact stored-FDA error message and does not query candidate list', async () => {
+    mongoMocks.retrieveFDA.mockResolvedValue(undefined);
+
+    await expect(
+      getFDA('svc', 'fdaX', undefined, '/public'),
+    ).rejects.toMatchObject({
+      status: 404,
+      type: 'FDANotFound',
+      message: 'FDA fdaX not found in service svc',
+    });
+
+    expect(mongoMocks.retrieveFDAs).not.toHaveBeenCalled();
+    expect(mongoMocks.retrieveFDA).toHaveBeenCalledWith(
+      'svc',
+      'fdaX',
+      '/public',
+    );
+  });
+
   test('returns accessible FDA when visibility is provided', async () => {
     mongoMocks.retrieveFDA.mockResolvedValue({
       _id: 'mongo1',

--- a/test/unit/freshQueriesHelpers.test.js
+++ b/test/unit/freshQueriesHelpers.test.js
@@ -24,7 +24,7 @@
 
 import { describe, expect, test } from '@jest/globals';
 import {
-  convertBigInt,
+  normalizeForSerialization,
   validateAllowedFieldsBody,
   parseBooleanQueryParam,
   assertFreshQueriesEnabled,
@@ -38,7 +38,7 @@ describe('fresh query helpers', () => {
     );
   });
 
-  test('convertBigInt converts bigint values recursively', () => {
+  test('normalizeForSerialization converts bigint values recursively', () => {
     const payload = {
       id: 7n,
       nested: {
@@ -46,7 +46,7 @@ describe('fresh query helpers', () => {
       },
     };
 
-    expect(convertBigInt(payload)).toEqual({
+    expect(normalizeForSerialization(payload)).toEqual({
       id: 7,
       nested: {
         values: [1, { count: 2 }],

--- a/test/unit/freshQueriesHelpers.test.js
+++ b/test/unit/freshQueriesHelpers.test.js
@@ -26,6 +26,7 @@ import { describe, expect, test } from '@jest/globals';
 import {
   normalizeForSerialization,
   validateAllowedFieldsBody,
+  validateForbiddenFieldsQuery,
   parseBooleanQueryParam,
   assertFreshQueriesEnabled,
   acquireFreshQuerySlot,
@@ -61,6 +62,14 @@ describe('fresh query helpers', () => {
         'description',
       ]),
     ).toThrow('Invalid fields in request body, check your request');
+  });
+
+  test('validateForbiddenFieldsQuery throws when query includes forbidden fields', () => {
+    expect(() =>
+      validateForbiddenFieldsQuery({ minAge: '25', outputType: 'csv' }, [
+        'outputType',
+      ]),
+    ).toThrow('Invalid fields in request query, check your request');
   });
 
   test('parseBooleanQueryParam parses valid values and rejects invalid ones', () => {

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -780,6 +780,79 @@ describe('index routes - validation and middleware branches', () => {
     expect(fdaMocks.executeQueryCsvStream).not.toHaveBeenCalled();
   });
 
+  test('defaults to JSON when no Accept header is sent', async () => {
+    fdaMocks.executeQuery.mockResolvedValueOnce([{ col: 1 }]);
+
+    const res = await request(app)
+      .get('/public/fdas/fda1/das/da1/data')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .expect(200);
+
+    expect(res.body).toEqual([{ col: 1 }]);
+    expect(fdaMocks.executeQuery).toHaveBeenCalled();
+    expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
+    expect(fdaMocks.executeQueryCsvStream).not.toHaveBeenCalled();
+  });
+
+  test('defaults to JSON when Accept is */*', async () => {
+    fdaMocks.executeQuery.mockResolvedValueOnce([{ col: 2 }]);
+
+    const res = await request(app)
+      .get('/public/fdas/fda1/das/da1/data')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .set('Accept', '*/*')
+      .expect(200);
+
+    expect(res.body).toEqual([{ col: 2 }]);
+    expect(fdaMocks.executeQuery).toHaveBeenCalled();
+    expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
+    expect(fdaMocks.executeQueryCsvStream).not.toHaveBeenCalled();
+  });
+
+  test('routes to CSV streaming when Accept is text/*', async () => {
+    await request(app)
+      .get('/public/fdas/fda1/das/da1/data')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .set('Accept', 'text/*')
+      .expect(200);
+
+    expect(fdaMocks.executeQueryCsvStream).toHaveBeenCalled();
+    expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
+    expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
+  });
+
+  test('uses q-value priority: skips unsupported type and picks ndjson over json', async () => {
+    await request(app)
+      .get('/public/fdas/fda1/das/da1/data')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .set('Accept', 'text/html;q=1.0, application/x-ndjson;q=0.8, */*;q=0.1')
+      .expect(200);
+
+    expect(fdaMocks.executeQueryStream).toHaveBeenCalled();
+    expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
+    expect(fdaMocks.executeQueryCsvStream).not.toHaveBeenCalled();
+  });
+
+  test('routes to xls when Accept is application/vnd.ms-excel', async () => {
+    fdaMocks.executeQuery.mockResolvedValueOnce([{ col: 'v' }]);
+
+    const res = await request(app)
+      .get('/public/fdas/fda1/das/da1/data')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .set('Accept', 'application/vnd.ms-excel')
+      .expect(200);
+
+    expect(res.headers['content-type']).toMatch(
+      /application\/vnd\.openxmlformats-officedocument\.spreadsheetml\.sheet/,
+    );
+    expect(fdaMocks.executeQuery).toHaveBeenCalled();
+  });
+
   test('routes data endpoint through CSV streaming when Accept requests csv', async () => {
     const res = await request(app)
       .get('/public/fdas/fda1/das/da1/data')

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -46,6 +46,7 @@ const fdaMocks = {
   fetchFDA: jest.fn(),
   executeQuery: jest.fn(),
   executeQueryStream: jest.fn(),
+  executeQueryCsvStream: jest.fn(),
   createDA: jest.fn(),
   getFDA: jest.fn(),
   updateFDA: jest.fn(),
@@ -103,6 +104,9 @@ function resetModuleMocks() {
   fdaMocks.executeQuery.mockReset().mockResolvedValue([{ ok: true }]);
   fdaMocks.executeQueryStream.mockReset().mockImplementation(({ res }) => {
     res.status(200).send('streamed');
+  });
+  fdaMocks.executeQueryCsvStream.mockReset().mockImplementation(({ res }) => {
+    res.status(200).send('streamed-csv');
   });
   fdaMocks.createDA.mockReset().mockResolvedValue(undefined);
   fdaMocks.getFDA.mockReset().mockResolvedValue({ fdaId: 'fda1' });
@@ -236,6 +240,7 @@ async function loadIndexModule({
     fetchFDA: fdaMocks.fetchFDA,
     executeQuery: fdaMocks.executeQuery,
     executeQueryStream: fdaMocks.executeQueryStream,
+    executeQueryCsvStream: fdaMocks.executeQueryCsvStream,
     assertFDAAccess: jest.fn(),
     createDA: fdaMocks.createDA,
     getFDA: fdaMocks.getFDA,
@@ -620,7 +625,7 @@ describe('index routes - validation and middleware branches', () => {
     expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
   });
 
-  test('uses NDJSON streaming when Accept is ndjson even if outputType is not json', async () => {
+  test('uses NDJSON streaming when Accept is ndjson even if outputType is present', async () => {
     await request(app)
       .get('/public/fdas/fda1/das/da1/data')
       .set('Fiware-Service', 'svc')
@@ -734,58 +739,50 @@ describe('index routes - validation and middleware branches', () => {
     expect(loggerMock.warn).toHaveBeenCalledWith(expect.any(Error));
   });
 
-  test('returns 400 for invalid outputType on data endpoint', async () => {
+  test('ignores outputType query param on data endpoint and defaults to JSON', async () => {
     const res = await request(app)
       .get('/public/fdas/fda1/das/da1/data')
       .set('Fiware-Service', 'svc')
       .set('Fiware-ServicePath', '/servicepath')
       .query({ outputType: 'xml' })
-      .expect(400);
+      .expect(200);
 
-    expect(res.body).toEqual({
-      error: 'BadRequest',
-      description: expect.stringContaining("Invalid outputType 'xml'"),
-    });
-    expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
+    expect(res.body).toEqual([{ ok: true }]);
+    expect(fdaMocks.executeQuery).toHaveBeenCalled();
   });
 
-  test('returns CSV when outputType=csv is requested on data endpoint', async () => {
-    fdaMocks.executeQuery.mockResolvedValueOnce([
-      { col1: 'a', col2: 'b' },
-      { col1: 'c,d', col2: 'e"f' },
-    ]);
-
+  test('routes data endpoint through CSV streaming when Accept requests csv', async () => {
     const res = await request(app)
       .get('/public/fdas/fda1/das/da1/data')
       .set('Fiware-Service', 'svc')
       .set('Fiware-ServicePath', '/servicepath')
-      .query({ outputType: 'csv' })
+      .set('Accept', 'text/csv')
+      .query({ fresh: 'true' })
       .expect(200);
 
-    expect(res.headers['content-type']).toMatch(/text\/csv/);
-    expect(res.headers['content-disposition']).toMatch(/attachment/);
-    const lines = res.text.split('\n');
-    expect(lines[0]).toBe('col1,col2');
-    expect(lines[1]).toBe('a,b');
-    expect(lines[2]).toBe('"c,d","e""f"');
-    expect(fdaMocks.executeQuery).toHaveBeenCalledWith(
+    expect(res.text).toBe('streamed-csv');
+    expect(fdaMocks.executeQueryCsvStream).toHaveBeenCalledWith(
       expect.objectContaining({
         service: 'svc',
         visibility: 'public',
         servicePath: '/servicepath',
-        params: expect.not.objectContaining({ outputType: 'csv' }),
+        fresh: false,
       }),
     );
+    expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
   });
 
-  test('returns Excel buffer when outputType=xls is requested on data endpoint', async () => {
+  test('returns Excel buffer when Accept requests xlsx on data endpoint', async () => {
     fdaMocks.executeQuery.mockResolvedValueOnce([{ col1: 'v1', col2: 42 }]);
 
     const res = await request(app)
       .get('/public/fdas/fda1/das/da1/data')
       .set('Fiware-Service', 'svc')
       .set('Fiware-ServicePath', '/servicepath')
-      .query({ outputType: 'xls' })
+      .set(
+        'Accept',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      )
       .expect(200);
 
     expect(res.headers['content-type']).toMatch(

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -88,6 +88,7 @@ const cdaMocks = {
 
 const utilsMocks = {
   validateAllowedFieldsBody: jest.fn(),
+  validateForbiddenFieldsQuery: jest.fn(),
   parseBooleanQueryParam: jest.fn(),
 };
 
@@ -149,6 +150,22 @@ function resetModuleMocks() {
   cdaMocks.handleCdaQuery.mockReset().mockResolvedValue({ rows: [] });
 
   utilsMocks.validateAllowedFieldsBody.mockReset().mockReturnValue(undefined);
+  utilsMocks.validateForbiddenFieldsQuery
+    .mockReset()
+    .mockImplementation((query, forbiddenFields) => {
+      const hasForbiddenField = Object.keys(query).some((key) =>
+        forbiddenFields.includes(key),
+      );
+
+      if (hasForbiddenField) {
+        const err = new Error(
+          'Invalid fields in request query, check your request',
+        );
+        err.status = 400;
+        err.type = 'BadRequest';
+        throw err;
+      }
+    });
   utilsMocks.parseBooleanQueryParam.mockReset().mockReturnValue(false);
 }
 
@@ -287,6 +304,7 @@ async function loadIndexModule({
 
   await jest.unstable_mockModule('../../src/lib/utils/utils.js', () => ({
     validateAllowedFieldsBody: utilsMocks.validateAllowedFieldsBody,
+    validateForbiddenFieldsQuery: utilsMocks.validateForbiddenFieldsQuery,
     parseBooleanQueryParam: utilsMocks.parseBooleanQueryParam,
   }));
 
@@ -637,8 +655,7 @@ describe('index routes - validation and middleware branches', () => {
 
     expect(res.body).toEqual({
       error: 'BadRequest',
-      description:
-        'Query param "outputType" is no longer supported. Use the Accept header for content negotiation.',
+      description: 'Invalid fields in request query, check your request',
     });
     expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
     expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
@@ -740,8 +757,7 @@ describe('index routes - validation and middleware branches', () => {
 
     expect(res.body).toEqual({
       error: 'BadRequest',
-      description:
-        'Query param "outputType" is no longer supported. Use the Accept header for content negotiation.',
+      description: 'Invalid fields in request query, check your request',
     });
     expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
   });

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -355,6 +355,93 @@ describe('index routes - validation and middleware branches', () => {
     await request(app).post('/plugin/cda/api/doQuery').send({}).expect(400);
   });
 
+  test('returns 400 when Fiware-ServicePath is missing in GET /:visibility/fdas', async () => {
+    await request(app)
+      .get('/public/fdas')
+      .set('Fiware-Service', 'svc')
+      .expect(400);
+  });
+
+  test('returns 400 when query is missing in POST /:visibility/fdas', async () => {
+    await request(app)
+      .post('/public/fdas')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .send({ id: 'fda1' })
+      .expect(400);
+  });
+
+  test('returns 400 when Fiware-Service is missing in GET /:visibility/fdas/:fdaId', async () => {
+    await request(app)
+      .get('/public/fdas/fda1')
+      .set('Fiware-ServicePath', '/servicepath')
+      .expect(400);
+  });
+
+  test('returns 400 when Fiware-ServicePath is missing in PUT /:visibility/fdas/:fdaId', async () => {
+    await request(app)
+      .put('/public/fdas/fda1')
+      .set('Fiware-Service', 'svc')
+      .send({})
+      .expect(400);
+  });
+
+  test('returns 400 when Fiware-Service is missing in DELETE /:visibility/fdas/:fdaId', async () => {
+    await request(app)
+      .delete('/public/fdas/fda1')
+      .set('Fiware-ServicePath', '/servicepath')
+      .expect(400);
+  });
+
+  test('returns 400 when Fiware-ServicePath is missing in GET /:visibility/fdas/:fdaId/das', async () => {
+    await request(app)
+      .get('/public/fdas/fda1/das')
+      .set('Fiware-Service', 'svc')
+      .expect(400);
+  });
+
+  test('returns 400 when required body fields are missing in POST /:visibility/fdas/:fdaId/das', async () => {
+    await request(app)
+      .post('/public/fdas/fda1/das')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .send({ id: 'da1' })
+      .expect(400);
+  });
+
+  test('returns 400 when Fiware-Service is missing in GET /:visibility/fdas/:fdaId/das/:daId', async () => {
+    await request(app)
+      .get('/public/fdas/fda1/das/da1')
+      .set('Fiware-ServicePath', '/servicepath')
+      .expect(400);
+  });
+
+  test('returns 400 when query is missing in PUT /:visibility/fdas/:fdaId/das/:daId', async () => {
+    await request(app)
+      .put('/public/fdas/fda1/das/da1')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .send({ description: 'desc only' })
+      .expect(400);
+  });
+
+  test('returns 400 when Fiware-Service is missing in GET /:visibility/fdas/:fdaId/das/:daId/data', async () => {
+    await request(app)
+      .get('/public/fdas/fda1/das/da1/data')
+      .set('Fiware-ServicePath', '/servicepath')
+      .set('Accept', 'application/json')
+      .expect(400);
+  });
+
+  test('returns 400 when dataAccessId is missing in POST /plugin/cda/api/doQuery', async () => {
+    await request(app)
+      .post('/plugin/cda/api/doQuery')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .send({ path: '/public/svc' })
+      .expect(400);
+  });
+
   test('covers health and successful CRUD-like route flows', async () => {
     fdaMocks.getFDAs.mockResolvedValueOnce([
       { id: 'fda1', visibility: 'public', servicePath: '/servicepath' },
@@ -697,6 +784,25 @@ describe('index routes - validation and middleware branches', () => {
       'Error executing query:',
       expect.any(Error),
     );
+  });
+
+  test('uses typed CDA adapter errors in /plugin/cda/api/doQuery response', async () => {
+    const typedErr = new Error('invalid query for tenant');
+    typedErr.status = 422;
+    typedErr.type = 'CDAValidationError';
+    cdaMocks.handleCdaQuery.mockRejectedValueOnce(typedErr);
+
+    const res = await request(app)
+      .post('/plugin/cda/api/doQuery')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .send({ path: '/public/svc', dataAccessId: 'da1' })
+      .expect(422);
+
+    expect(res.body).toEqual({
+      error: 'CDAValidationError',
+      description: 'invalid query for tenant',
+    });
   });
 
   test('covers middleware capture fallback for unserializable payloads', async () => {

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -319,8 +319,6 @@ describe('index routes - validation and middleware branches', () => {
 
   test('returns 400 for missing mandatory params across route guards', async () => {
     await request(app).get('/public/fdas').expect(400);
-    await request(app).post('/public/fdas').send({}).expect(400);
-    await request(app).get('/public/fdas/fda1').expect(400);
     await request(app).put('/public/fdas/fda1').expect(400);
     await request(app).delete('/public/fdas/fda1').expect(400);
 
@@ -625,8 +623,8 @@ describe('index routes - validation and middleware branches', () => {
     expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
   });
 
-  test('uses NDJSON streaming when Accept is ndjson even if outputType is present', async () => {
-    await request(app)
+  test('rejects outputType on data endpoint even when Accept is ndjson', async () => {
+    const res = await request(app)
       .get('/public/fdas/fda1/das/da1/data')
       .set('Fiware-Service', 'svc')
       .set('Fiware-ServicePath', '/servicepath')
@@ -635,22 +633,15 @@ describe('index routes - validation and middleware branches', () => {
         outputType: 'csv',
         minAge: 25,
       })
-      .expect(200)
-      .expect('streamed');
+      .expect(400);
 
-    expect(fdaMocks.executeQueryStream).toHaveBeenCalledWith(
-      expect.objectContaining({
-        service: 'svc',
-        visibility: 'public',
-        servicePath: '/servicepath',
-        params: expect.objectContaining({
-          fdaId: 'fda1',
-          daId: 'da1',
-          minAge: '25',
-        }),
-      }),
-    );
+    expect(res.body).toEqual({
+      error: 'BadRequest',
+      description:
+        'Query param "outputType" is no longer supported. Use the Accept header for content negotiation.',
+    });
     expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
+    expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
   });
 
   test('covers DELETE DA route success path', async () => {
@@ -739,16 +730,38 @@ describe('index routes - validation and middleware branches', () => {
     expect(loggerMock.warn).toHaveBeenCalledWith(expect.any(Error));
   });
 
-  test('ignores outputType query param on data endpoint and defaults to JSON', async () => {
+  test('rejects outputType query param on data endpoint', async () => {
     const res = await request(app)
       .get('/public/fdas/fda1/das/da1/data')
       .set('Fiware-Service', 'svc')
       .set('Fiware-ServicePath', '/servicepath')
       .query({ outputType: 'xml' })
-      .expect(200);
+      .expect(400);
 
-    expect(res.body).toEqual([{ ok: true }]);
-    expect(fdaMocks.executeQuery).toHaveBeenCalled();
+    expect(res.body).toEqual({
+      error: 'BadRequest',
+      description:
+        'Query param "outputType" is no longer supported. Use the Accept header for content negotiation.',
+    });
+    expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
+  });
+
+  test('returns 406 for unsupported Accept header on data endpoint', async () => {
+    const res = await request(app)
+      .get('/public/fdas/fda1/das/da1/data')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .set('Accept', 'video/mpg4')
+      .expect(406);
+
+    expect(res.body).toEqual({
+      error: 'NotAcceptable',
+      description:
+        'Accept header must allow application/json, application/x-ndjson, text/csv, or application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+    expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
+    expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
+    expect(fdaMocks.executeQueryCsvStream).not.toHaveBeenCalled();
   });
 
   test('routes data endpoint through CSV streaming when Accept requests csv', async () => {

--- a/test/unit/pgUtils.test.js
+++ b/test/unit/pgUtils.test.js
@@ -61,6 +61,10 @@ await jest.unstable_mockModule('pg', () => ({
   default: {
     Client: clientCtorMock,
     Pool: poolCtorMock,
+    types: {
+      setTypeParser: jest.fn(),
+      builtins: { INT8: 20 },
+    },
   },
 }));
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -49,6 +49,35 @@ describe('utils', () => {
     jest.clearAllMocks();
   });
 
+  describe('convertBigInt', () => {
+    test('converts Date values to ISO strings recursively', async () => {
+      const { convertBigInt } = await loadUtilsModule();
+      const value = {
+        date: new Date('2026-04-08T10:11:12.000Z'),
+        nested: [new Date('2026-04-08T10:11:13.000Z')],
+      };
+
+      expect(convertBigInt(value)).toEqual({
+        date: '2026-04-08T10:11:12.000Z',
+        nested: ['2026-04-08T10:11:13.000Z'],
+      });
+    });
+
+    test('converts bigint values to numbers recursively', async () => {
+      const { convertBigInt } = await loadUtilsModule();
+
+      expect(
+        convertBigInt({
+          count: 1n,
+          nested: { values: [2n] },
+        }),
+      ).toEqual({
+        count: 1,
+        nested: { values: [2] },
+      });
+    });
+  });
+
   describe('parseBooleanQueryParam', () => {
     test('returns false when value is undefined', async () => {
       const { parseBooleanQueryParam } = await loadUtilsModule();

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -49,25 +49,25 @@ describe('utils', () => {
     jest.clearAllMocks();
   });
 
-  describe('convertBigInt', () => {
+  describe('normalizeForSerialization', () => {
     test('converts Date values to ISO strings recursively', async () => {
-      const { convertBigInt } = await loadUtilsModule();
+      const { normalizeForSerialization } = await loadUtilsModule();
       const value = {
         date: new Date('2026-04-08T10:11:12.000Z'),
         nested: [new Date('2026-04-08T10:11:13.000Z')],
       };
 
-      expect(convertBigInt(value)).toEqual({
+      expect(normalizeForSerialization(value)).toEqual({
         date: '2026-04-08T10:11:12.000Z',
         nested: ['2026-04-08T10:11:13.000Z'],
       });
     });
 
     test('converts bigint values to numbers recursively', async () => {
-      const { convertBigInt } = await loadUtilsModule();
+      const { normalizeForSerialization } = await loadUtilsModule();
 
       expect(
-        convertBigInt({
+        normalizeForSerialization({
           count: 1n,
           nested: { values: [2n] },
         }),


### PR DESCRIPTION
Related Issue: #137

Fixes serialization inconsistencies in `fresh=true` queries (#137) and hardens data content negotiation and request validation.

- **Serialization consistency (`fresh=true`)**: `Date` values are now always serialized as ISO 8601 strings, and `int8`/`BigInt` values as numbers across JSON, NDJSON and CSV, matching cached-query behavior.
- **data contract enforcement**: `outputType` query param is now rejected with `400 BadRequest` (generic invalid-query-fields error). Output format remains selected via `Accept` header only.
- **HTTP `Accept` negotiation fixed**: data now relies on framework-level Accept parsing (wildcards and q-values), covering cases like `*/*` (default JSON), `text/*` (CSV), and weighted lists (e.g. fallback from unsupported `text/html` to `application/json`).
- **Tests added**: explicit coverage for wildcard/q-value Accept behavior and additional branch coverage around stored FDA retrieval and streaming paths.
- **New utility**: `validateForbiddenFieldsQuery`, aligned with existing validation helpers, now used by data.