### PR TITLE
Fix output format follow-up

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,6 @@ import {
   fetchFDA,
   executeQuery,
   executeQueryStream,
-  executeQueryCsvStream,
   createDA,
   getFDA,
   updateFDA,
@@ -90,6 +89,27 @@ const DATA_ACCEPT_CONTENT_TYPE_TO_OUTPUT = {
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xls',
   'application/vnd.ms-excel': 'xls',
 };
+
+async function sendRowsByOutputType(res, rows, outputType) {
+  if (outputType === 'csv') {
+    const csv = rowsToCsv(rows);
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', 'attachment; filename="results.csv"');
+    return res.send(csv);
+  }
+
+  if (outputType === 'xls') {
+    const buffer = await rowsToXlsx(rows);
+    res.setHeader(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+    res.setHeader('Content-Disposition', 'attachment; filename="results.xlsx"');
+    return res.send(Buffer.from(buffer));
+  }
+
+  return res.json(rows);
+}
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
@@ -431,7 +451,7 @@ app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
     ...queryParams,
   };
 
-  if (outputType === 'ndjson') {
+  if (outputType === 'ndjson' || outputType === 'csv') {
     return executeQueryStream({
       service,
       visibility,
@@ -440,18 +460,7 @@ app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
       req,
       res,
       fresh,
-    });
-  }
-
-  if (outputType === 'csv') {
-    return executeQueryCsvStream({
-      service,
-      visibility,
-      servicePath,
-      params,
-      req,
-      res,
-      fresh,
+      format: outputType,
     });
   }
 
@@ -463,17 +472,7 @@ app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
     fresh,
   });
 
-  if (outputType === 'xls') {
-    const buffer = await rowsToXlsx(rows);
-    res.setHeader(
-      'Content-Type',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    );
-    res.setHeader('Content-Disposition', 'attachment; filename="results.xlsx"');
-    return res.send(Buffer.from(buffer));
-  }
-
-  return res.json(rows);
+  return sendRowsByOutputType(res, rows, outputType);
 });
 
 app.post('/plugin/cda/api/doQuery', async (req, res) => {
@@ -502,30 +501,7 @@ app.post('/plugin/cda/api/doQuery', async (req, res) => {
       outputType: rawOutputType,
     });
 
-    if (rawOutputType === 'csv') {
-      const csv = rowsToCsv(result);
-      res.setHeader('Content-Type', 'text/csv');
-      res.setHeader(
-        'Content-Disposition',
-        'attachment; filename="results.csv"',
-      );
-      return res.send(csv);
-    }
-
-    if (rawOutputType === 'xls') {
-      const buffer = await rowsToXlsx(result);
-      res.setHeader(
-        'Content-Type',
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      );
-      res.setHeader(
-        'Content-Disposition',
-        'attachment; filename="results.xlsx"',
-      );
-      return res.send(Buffer.from(buffer));
-    }
-
-    return res.json(result);
+    return sendRowsByOutputType(res, result, rawOutputType);
   } catch (err) {
     logger.error('Error executing query:', err);
     const status = err.status || 500;

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -218,81 +218,16 @@ export async function executeQueryStream({
   res,
   fresh = false,
 }) {
-  if (fresh) {
-    return executeFreshQueryStream({
-      service,
-      visibility,
-      servicePath,
-      params,
-      req,
-      res,
-    });
-  }
-
-  const { fdaId, daId, ...rest } = params;
-
-  await ensureFDAReadyForQuery(service, fdaId, visibility, servicePath);
-
-  const conn = await getDBConnection();
-
-  let stream;
-  let close;
-
-  try {
-    const result = await runPreparedStatementStream(
-      conn,
-      service,
-      fdaId,
-      daId,
-      rest,
-      servicePath,
-    );
-
-    stream = result.stream;
-    close = result.close;
-  } catch (err) {
-    await releaseDBConnection(conn);
-    throw err;
-  }
-
-  let cleaned = false;
-
-  const cleanup = async () => {
-    if (cleaned) {
-      return;
-    }
-    cleaned = true;
-
-    try {
-      await close();
-    } finally {
-      await releaseDBConnection(conn);
-    }
-  };
-
-  req.on('close', () => {
-    cleanup().catch(() => {});
+  return executeQueryAsStream({
+    service,
+    visibility,
+    servicePath,
+    params,
+    req,
+    res,
+    fresh,
+    format: 'ndjson',
   });
-
-  res.setHeader('Content-Type', 'application/x-ndjson');
-
-  try {
-    const columnNames = stream.columnNames();
-    for (
-      let chunk = await stream.fetchChunk();
-      chunk.rowCount > 0;
-      chunk = await stream.fetchChunk()
-    ) {
-      const rows = chunk.getRows();
-      for (const row of rows) {
-        await writeNdjsonLine(res, toRowObject(row, columnNames));
-      }
-    }
-  } finally {
-    await cleanup();
-  }
-
-  return res.end();
 }
 
 export async function executeQueryCsvStream({
@@ -304,17 +239,96 @@ export async function executeQueryCsvStream({
   res,
   fresh = false,
 }) {
-  if (fresh) {
-    return executeFreshQueryCsvStream({
-      service,
-      visibility,
-      servicePath,
-      params,
-      req,
-      res,
-    });
+  return executeQueryAsStream({
+    service,
+    visibility,
+    servicePath,
+    params,
+    req,
+    res,
+    fresh,
+    format: 'csv',
+  });
+}
+
+async function executeQueryAsStream({
+  service,
+  visibility,
+  servicePath,
+  params,
+  req,
+  res,
+  fresh,
+  format,
+}) {
+  const source = fresh
+    ? await createFreshRowSource({
+        service,
+        visibility,
+        servicePath,
+        params,
+        req,
+      })
+    : await createCachedRowSource({
+        service,
+        visibility,
+        servicePath,
+        params,
+        req,
+      });
+
+  if (format === 'ndjson') {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+  } else {
+    res.setHeader('Content-Type', CSV_CONTENT_TYPE);
+    res.setHeader('Content-Disposition', 'attachment; filename="results.csv"');
   }
 
+  let csvColumns;
+
+  try {
+    for (
+      let rows = await source.readNextRows();
+      rows.length > 0;
+      rows = await source.readNextRows()
+    ) {
+      if (format === 'ndjson') {
+        for (const row of rows) {
+          const rowObj = source.columnNames
+            ? toRowObject(row, source.columnNames)
+            : row;
+          await writeNdjsonLine(res, rowObj);
+        }
+        continue;
+      }
+
+      if (!csvColumns) {
+        csvColumns = source.columnNames ?? Object.keys(rows[0] ?? {});
+        await writeCsvHeader(res, csvColumns);
+      }
+
+      for (const row of rows) {
+        const csvLine = source.columnNames
+          ? row.map((cell) => escapeCsvValue(cell)).join(',') + '\n'
+          : csvColumns.map((column) => escapeCsvValue(row[column])).join(',') +
+            '\n';
+        await writeCsvLine(res, csvLine);
+      }
+    }
+  } finally {
+    await source.close();
+  }
+
+  return res.end();
+}
+
+async function createCachedRowSource({
+  service,
+  visibility,
+  servicePath,
+  params,
+  req,
+}) {
   const { fdaId, daId, ...rest } = params;
 
   await ensureFDAReadyForQuery(service, fdaId, visibility, servicePath);
@@ -322,7 +336,7 @@ export async function executeQueryCsvStream({
   const conn = await getDBConnection();
 
   let stream;
-  let close;
+  let closeStream;
 
   try {
     const result = await runPreparedStatementStream(
@@ -335,14 +349,13 @@ export async function executeQueryCsvStream({
     );
 
     stream = result.stream;
-    close = result.close;
+    closeStream = result.close;
   } catch (err) {
     await releaseDBConnection(conn);
     throw err;
   }
 
   let cleaned = false;
-
   const cleanup = async () => {
     if (cleaned) {
       return;
@@ -350,7 +363,7 @@ export async function executeQueryCsvStream({
     cleaned = true;
 
     try {
-      await close();
+      await closeStream();
     } finally {
       await releaseDBConnection(conn);
     }
@@ -360,31 +373,61 @@ export async function executeQueryCsvStream({
     cleanup().catch(() => {});
   });
 
-  res.setHeader('Content-Type', CSV_CONTENT_TYPE);
-  res.setHeader('Content-Disposition', 'attachment; filename="results.csv"');
+  return {
+    columnNames: stream.columnNames(),
+    async readNextRows() {
+      const chunk = await stream.fetchChunk();
+      return chunk.rowCount > 0 ? chunk.getRows() : [];
+    },
+    close: cleanup,
+  };
+}
+
+async function createFreshRowSource({
+  service,
+  visibility,
+  servicePath,
+  params,
+  req,
+}) {
+  assertFreshQueriesEnabled(config.roles.syncQueries);
+
+  const releaseFreshSlot = acquireFreshQuerySlot(
+    config.freshQueries.maxConcurrent,
+  );
+  let cursorReader;
 
   try {
-    const columnNames = stream.columnNames();
-    await writeCsvHeader(res, columnNames);
+    const { text, values } = await buildFreshQueryStatement(
+      service,
+      visibility,
+      servicePath,
+      params,
+    );
 
-    for (
-      let chunk = await stream.fetchChunk();
-      chunk.rowCount > 0;
-      chunk = await stream.fetchChunk()
-    ) {
-      const rows = chunk.getRows();
+    cursorReader = await createPgCursorReader(
+      service,
+      text,
+      values,
+      FRESH_CURSOR_BATCH_SIZE,
+    );
 
-      for (const row of rows) {
-        const csvLine =
-          row.map((cell) => escapeCsvValue(cell)).join(',') + '\n';
-        await writeCsvLine(res, csvLine);
-      }
-    }
-  } finally {
-    await cleanup();
+    req.on('close', () => {
+      cursorReader?.close().catch(() => {});
+    });
+
+    return {
+      columnNames: null,
+      readNextRows: async () => cursorReader.readNextChunk(),
+      close: async () => {
+        await cursorReader?.close();
+        releaseFreshSlot();
+      },
+    };
+  } catch (e) {
+    releaseFreshSlot();
+    throw e;
   }
-
-  return res.end();
 }
 
 async function executeFreshQuery({ service, visibility, servicePath, params }) {
@@ -412,134 +455,6 @@ async function executeFreshQuery({ service, visibility, servicePath, params }) {
   } finally {
     releaseFreshSlot();
   }
-}
-
-async function executeFreshQueryStream({
-  service,
-  visibility,
-  servicePath,
-  params,
-  req,
-  res,
-}) {
-  assertFreshQueriesEnabled(config.roles.syncQueries);
-
-  const releaseFreshSlot = acquireFreshQuerySlot(
-    config.freshQueries.maxConcurrent,
-  );
-  let cursorReader;
-
-  try {
-    const { text, values } = await buildFreshQueryStatement(
-      service,
-      visibility,
-      servicePath,
-      params,
-    );
-
-    cursorReader = await createPgCursorReader(
-      service,
-      text,
-      values,
-      FRESH_CURSOR_BATCH_SIZE,
-    );
-
-    req.on('close', () => {
-      cursorReader?.close().catch(() => {});
-    });
-
-    res.setHeader('Content-Type', 'application/x-ndjson');
-
-    for (
-      let rows = await cursorReader.readNextChunk();
-      rows.length > 0;
-      rows = await cursorReader.readNextChunk()
-    ) {
-      for (const row of rows) {
-        await writeNdjsonLine(res, row);
-      }
-    }
-  } catch (e) {
-    if (e instanceof FDAError) {
-      throw e;
-    }
-
-    throw e;
-  } finally {
-    await cursorReader?.close();
-    releaseFreshSlot();
-  }
-
-  return res.end();
-}
-
-async function executeFreshQueryCsvStream({
-  service,
-  visibility,
-  servicePath,
-  params,
-  req,
-  res,
-}) {
-  assertFreshQueriesEnabled(config.roles.syncQueries);
-
-  const releaseFreshSlot = acquireFreshQuerySlot(
-    config.freshQueries.maxConcurrent,
-  );
-  let cursorReader;
-
-  try {
-    const { text, values } = await buildFreshQueryStatement(
-      service,
-      visibility,
-      servicePath,
-      params,
-    );
-
-    cursorReader = await createPgCursorReader(
-      service,
-      text,
-      values,
-      FRESH_CURSOR_BATCH_SIZE,
-    );
-
-    req.on('close', () => {
-      cursorReader?.close().catch(() => {});
-    });
-
-    res.setHeader('Content-Type', CSV_CONTENT_TYPE);
-    res.setHeader('Content-Disposition', 'attachment; filename="results.csv"');
-
-    let columns;
-
-    for (
-      let rows = await cursorReader.readNextChunk();
-      rows.length > 0;
-      rows = await cursorReader.readNextChunk()
-    ) {
-      if (!columns) {
-        columns = Object.keys(rows[0]);
-        await writeCsvHeader(res, columns);
-      }
-
-      for (const row of rows) {
-        const csvLine =
-          columns.map((column) => escapeCsvValue(row[column])).join(',') + '\n';
-        await writeCsvLine(res, csvLine);
-      }
-    }
-  } catch (e) {
-    if (e instanceof FDAError) {
-      throw e;
-    }
-
-    throw e;
-  } finally {
-    await cursorReader?.close();
-    releaseFreshSlot();
-  }
-
-  return res.end();
 }
 
 async function buildFreshQueryStatement(

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -110,6 +110,36 @@ async function writeCsvLine(res, line) {
   }
 }
 
+async function writeNdjsonLine(res, row) {
+  const safeObj = normalizeForSerialization(row);
+  const ok = res.write(JSON.stringify(safeObj) + '\n');
+  if (!ok) {
+    await new Promise((resolve) => res.once('drain', resolve));
+  }
+}
+
+async function writeCsvHeader(res, columnNames) {
+  if (columnNames.length === 0) {
+    return;
+  }
+
+  await writeCsvLine(
+    res,
+    columnNames.map((columnName) => escapeCsvValue(columnName)).join(',') +
+      '\n',
+  );
+}
+
+function toRowObject(row, columnNames) {
+  const rowObj = {};
+
+  for (let i = 0; i < columnNames.length; i++) {
+    rowObj[columnNames[i]] = row[i];
+  }
+
+  return rowObj;
+}
+
 export async function getFDAs(service, visibility, servicePath) {
   const fdas = await retrieveFDAs(service);
   const normalizedServicePath = normalizeServicePath(servicePath);
@@ -164,7 +194,7 @@ export async function executeQuery({
   const conn = await getDBConnection();
 
   try {
-    return await runPreparedStatement(
+    const rows = await runPreparedStatement(
       conn,
       service,
       fdaId,
@@ -172,6 +202,8 @@ export async function executeQuery({
       rest,
       servicePath,
     );
+
+    return normalizeForSerialization(rows);
   } finally {
     await releaseDBConnection(conn);
   }
@@ -252,25 +284,8 @@ export async function executeQueryStream({
       chunk = await stream.fetchChunk()
     ) {
       const rows = chunk.getRows();
-
-      const lines = [];
-
       for (const row of rows) {
-        const rowObj = {};
-
-        for (let i = 0; i < columnNames.length; i++) {
-          rowObj[columnNames[i]] = row[i];
-        }
-
-        const safeObj = normalizeForSerialization(rowObj);
-        lines.push(JSON.stringify(safeObj));
-      }
-
-      const payload = lines.join('\n') + '\n';
-
-      const ok = res.write(payload);
-      if (!ok) {
-        await new Promise((resolve) => res.once('drain', resolve));
+        await writeNdjsonLine(res, toRowObject(row, columnNames));
       }
     }
   } finally {
@@ -350,13 +365,7 @@ export async function executeQueryCsvStream({
 
   try {
     const columnNames = stream.columnNames();
-    if (columnNames.length > 0) {
-      await writeCsvLine(
-        res,
-        columnNames.map((columnName) => escapeCsvValue(columnName)).join(',') +
-          '\n',
-      );
-    }
+    await writeCsvHeader(res, columnNames);
 
     for (
       let chunk = await stream.fetchChunk();
@@ -447,11 +456,7 @@ async function executeFreshQueryStream({
       rows = await cursorReader.readNextChunk()
     ) {
       for (const row of rows) {
-        const safeObj = normalizeForSerialization(row);
-        const ok = res.write(JSON.stringify(safeObj) + '\n');
-        if (!ok) {
-          await new Promise((resolve) => res.once('drain', resolve));
-        }
+        await writeNdjsonLine(res, row);
       }
     }
   } catch (e) {
@@ -514,13 +519,7 @@ async function executeFreshQueryCsvStream({
     ) {
       if (!columns) {
         columns = Object.keys(rows[0]);
-        if (columns.length > 0) {
-          await writeCsvLine(
-            res,
-            columns.map((columnName) => escapeCsvValue(columnName)).join(',') +
-              '\n',
-          );
-        }
+        await writeCsvHeader(res, columns);
       }
 
       for (const row of rows) {

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -376,7 +376,7 @@ async function createFreshRowSource({
 
     return {
       columnNames: null,
-      readNextRows: async () => cursorReader.readNextChunk(),
+      readNextRows: () => cursorReader.readNextChunk(),
       close: async () => {
         await cursorReader?.close();
         releaseFreshSlot();

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -217,49 +217,7 @@ export async function executeQueryStream({
   req,
   res,
   fresh = false,
-}) {
-  return executeQueryAsStream({
-    service,
-    visibility,
-    servicePath,
-    params,
-    req,
-    res,
-    fresh,
-    format: 'ndjson',
-  });
-}
-
-export async function executeQueryCsvStream({
-  service,
-  visibility,
-  servicePath,
-  params,
-  req,
-  res,
-  fresh = false,
-}) {
-  return executeQueryAsStream({
-    service,
-    visibility,
-    servicePath,
-    params,
-    req,
-    res,
-    fresh,
-    format: 'csv',
-  });
-}
-
-async function executeQueryAsStream({
-  service,
-  visibility,
-  servicePath,
-  params,
-  req,
-  res,
-  fresh,
-  format,
+  format = 'ndjson',
 }) {
   const source = fresh
     ? await createFreshRowSource({

--- a/src/lib/utils/utils.js
+++ b/src/lib/utils/utils.js
@@ -26,10 +26,41 @@ import { FDAError } from '../fdaError.js';
 
 let activeFreshQueries = 0;
 
+function toIsoFromMicros(value) {
+  const micros = typeof value === 'bigint' ? Number(value) : Number(value);
+  if (!Number.isFinite(micros)) {
+    return undefined;
+  }
+
+  return new Date(micros / 1000).toISOString();
+}
+
+function toIsoFromTimestampString(value) {
+  const match = value.match(
+    /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)([+-]\d{2})(?::?(\d{2}))?$/,
+  );
+  if (!match) {
+    return undefined;
+  }
+
+  const [, datePart, timePart, offsetHours, offsetMinutes = '00'] = match;
+  const parsed = new Date(
+    `${datePart}T${timePart}${offsetHours}:${offsetMinutes}`,
+  );
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+
+  return parsed.toISOString();
+}
+
 // Normalize runtime values so downstream serializers emit stable output.
 export function normalizeForSerialization(obj) {
   if (typeof obj === 'bigint') {
     return Number(obj);
+  }
+  if (typeof obj === 'string') {
+    return toIsoFromTimestampString(obj) ?? obj;
   }
   if (obj instanceof Date) {
     return obj.toISOString();
@@ -38,6 +69,14 @@ export function normalizeForSerialization(obj) {
     return obj.map(normalizeForSerialization);
   }
   if (obj !== null && typeof obj === 'object') {
+    const keys = Object.keys(obj);
+    if (keys.length === 1 && keys[0] === 'micros') {
+      const isoDate = toIsoFromMicros(obj.micros);
+      if (isoDate) {
+        return isoDate;
+      }
+    }
+
     const converted = {};
     for (const key in obj) {
       converted[key] = normalizeForSerialization(obj[key]);

--- a/src/lib/utils/utils.js
+++ b/src/lib/utils/utils.js
@@ -27,7 +27,7 @@ import { FDAError } from '../fdaError.js';
 let activeFreshQueries = 0;
 
 function toIsoFromMicros(value) {
-  const micros = typeof value === 'bigint' ? Number(value) : Number(value);
+  const micros = Number(value);
   if (!Number.isFinite(micros)) {
     return undefined;
   }

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -1776,123 +1776,228 @@ export function runFDAIntegrationSuite({ mode, label }) {
       }
     });
 
-    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data serializes date consistently for fresh CSV/NDJSON and keeps numeric types in NDJSON', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data serializes dates consistently across cached and fresh JSON/NDJSON/CSV', async () => {
+      const fixtureTable = 'format_serialization_fixture';
       const fdaSerializationId = 'fda_serialization_regression';
       const daSerializationId = 'da_serialization_regression';
+      const expectedDates = [
+        '2024-01-10T12:34:56.789Z',
+        '2024-01-11T08:15:30.123Z',
+      ];
 
-      const createFda = await httpReq({
-        method: 'POST',
-        url: `${baseUrl}/${visibility}/fdas`,
-        headers: {
-          'Fiware-Service': service,
-          'Fiware-ServicePath': servicePath,
-        },
-        body: {
-          id: fdaSerializationId,
-          description: 'issue 137 serialization regression fda',
-          query: `
-            SELECT
-              id,
-              timeinstant AS date,
-              EXTRACT(DAY FROM timeinstant)::INT AS day,
-              COUNT(*) OVER() AS countperperiod
-            FROM public.users
-            ORDER BY id
+      const pgClient = new Client({
+        host: pgHost,
+        port: pgPort,
+        user: 'postgres',
+        password: 'postgres',
+        database: service,
+      });
+
+      await connectWithRetry(pgClient);
+
+      try {
+        await pgClient.query(`DROP TABLE IF EXISTS public.${fixtureTable}`);
+        await pgClient.query(`
+          CREATE TABLE public.${fixtureTable} (
+            id INT PRIMARY KEY,
+            observed_at TIMESTAMPTZ NOT NULL,
+            total_bigint BIGINT NOT NULL,
+            note TEXT
+          )
+        `);
+        await pgClient.query(
+          `
+            INSERT INTO public.${fixtureTable} (id, observed_at, total_bigint, note)
+            VALUES
+              (1, $1::timestamptz, 42, 'alpha'),
+              (2, $2::timestamptz, 84, 'with,comma')
           `,
-        },
-      });
+          expectedDates,
+        );
 
-      expect(createFda.status).toBe(202);
+        const createFda = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+          body: {
+            id: fdaSerializationId,
+            description: 'issue 137 format matrix regression fda',
+            query: `
+              SELECT
+                id,
+                observed_at AS date,
+                total_bigint AS total,
+                note
+              FROM public.${fixtureTable}
+              ORDER BY id
+            `,
+          },
+        });
 
-      await waitUntilFDACompleted({
-        baseUrl,
-        service,
-        fdaId: fdaSerializationId,
-      });
+        expect(createFda.status).toBe(202);
 
-      const createDa = await httpReq({
-        method: 'POST',
-        url: `${baseUrl}/${visibility}/fdas/${fdaSerializationId}/das`,
-        headers: { 'Fiware-Service': service },
-        body: {
-          id: daSerializationId,
-          description: 'issue 137 serialization regression da',
-          query: `
-            SELECT date, day, countperperiod
-            ORDER BY day, date
-          `,
-        },
-      });
-
-      expect(createDa.status).toBe(201);
-
-      const cachedCsv = await httpReqRaw({
-        method: 'GET',
-        url: buildDaDataUrl(
+        await waitUntilFDACompleted({
           baseUrl,
-          servicePath,
-          fdaSerializationId,
-          daSerializationId,
-        ),
-        headers: {
-          'Fiware-Service': service,
-          Accept: 'text/csv',
-        },
-      });
+          service,
+          fdaId: fdaSerializationId,
+        });
 
-      expect(cachedCsv.status).toBe(200);
-      expect(cachedCsv.headers['content-type']).toContain('text/csv');
-      expect(cachedCsv.text).not.toContain('[object Object]');
+        const createDa = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas/${fdaSerializationId}/das`,
+          headers: { 'Fiware-Service': service },
+          body: {
+            id: daSerializationId,
+            description: 'issue 137 format matrix regression da',
+            query: `
+              SELECT date, total, note
+              ORDER BY date
+            `,
+          },
+        });
 
-      const freshCsv = await httpReqRaw({
-        method: 'GET',
-        url: buildDaDataUrl(
-          baseUrl,
-          servicePath,
-          fdaSerializationId,
-          daSerializationId,
-          { fresh: true },
-        ),
-        headers: {
-          'Fiware-Service': service,
-          Accept: 'text/csv',
-        },
-      });
+        expect(createDa.status).toBe(201);
 
-      expect(freshCsv.status).toBe(200);
-      expect(freshCsv.headers['content-type']).toContain('text/csv');
-      expect(freshCsv.text).not.toContain('[object Object]');
+        const cachedJson = await httpReq({
+          method: 'GET',
+          url: buildDaDataUrl(
+            baseUrl,
+            servicePath,
+            fdaSerializationId,
+            daSerializationId,
+          ),
+          headers: {
+            'Fiware-Service': service,
+            Accept: 'application/json',
+          },
+        });
 
-      const freshNdjson = await httpReqRaw({
-        method: 'GET',
-        url: buildDaDataUrl(
-          baseUrl,
-          servicePath,
-          fdaSerializationId,
-          daSerializationId,
-          { fresh: true },
-        ),
-        headers: {
-          'Fiware-Service': service,
-          Accept: 'application/x-ndjson',
-        },
-      });
+        expect(cachedJson.status).toBe(200);
+        expect(cachedJson.json.map((row) => row.date)).toEqual(expectedDates);
+        expect(
+          cachedJson.json.every((row) =>
+            ['string', 'number'].includes(typeof row.total),
+          ),
+        ).toBe(true);
 
-      expect(freshNdjson.status).toBe(200);
-      expect(freshNdjson.headers['content-type']).toContain(
-        'application/x-ndjson',
-      );
+        const cachedNdjson = await httpReqRaw({
+          method: 'GET',
+          url: buildDaDataUrl(
+            baseUrl,
+            servicePath,
+            fdaSerializationId,
+            daSerializationId,
+          ),
+          headers: {
+            'Fiware-Service': service,
+            Accept: 'application/x-ndjson',
+          },
+        });
 
-      const rows = freshNdjson.text
-        .split('\n')
-        .filter((line) => line.trim())
-        .map((line) => JSON.parse(line));
+        expect(cachedNdjson.status).toBe(200);
+        const cachedNdjsonRows = cachedNdjson.text
+          .split('\n')
+          .filter((line) => line.trim())
+          .map((line) => JSON.parse(line));
+        expect(cachedNdjsonRows.map((row) => row.date)).toEqual(expectedDates);
+        expect(
+          cachedNdjsonRows.every((row) =>
+            ['string', 'number'].includes(typeof row.total),
+          ),
+        ).toBe(true);
 
-      expect(rows.length).toBeGreaterThan(0);
-      expect(typeof rows[0].date).toBe('string');
-      expect(rows[0].date).not.toEqual({});
-      expect(rows[0].date).toContain('T');
-      expect(typeof rows[0].countperperiod).toBe('number');
+        const cachedCsv = await httpReqRaw({
+          method: 'GET',
+          url: buildDaDataUrl(
+            baseUrl,
+            servicePath,
+            fdaSerializationId,
+            daSerializationId,
+          ),
+          headers: {
+            'Fiware-Service': service,
+            Accept: 'text/csv',
+          },
+        });
+
+        expect(cachedCsv.status).toBe(200);
+        expect(cachedCsv.headers['content-type']).toContain('text/csv');
+        expect(cachedCsv.text).toContain(expectedDates[0]);
+        expect(cachedCsv.text).toContain(expectedDates[1]);
+        expect(cachedCsv.text).not.toContain('[object Object]');
+
+        const freshJson = await httpReq({
+          method: 'GET',
+          url: buildDaDataUrl(
+            baseUrl,
+            servicePath,
+            fdaSerializationId,
+            daSerializationId,
+            { fresh: true },
+          ),
+          headers: {
+            'Fiware-Service': service,
+            Accept: 'application/json',
+          },
+        });
+
+        expect(freshJson.status).toBe(200);
+        expect(freshJson.json.map((row) => row.date)).toEqual(expectedDates);
+        expect(freshJson.json.map((row) => row.total)).toEqual([42, 84]);
+
+        const freshNdjson = await httpReqRaw({
+          method: 'GET',
+          url: buildDaDataUrl(
+            baseUrl,
+            servicePath,
+            fdaSerializationId,
+            daSerializationId,
+            { fresh: true },
+          ),
+          headers: {
+            'Fiware-Service': service,
+            Accept: 'application/x-ndjson',
+          },
+        });
+
+        expect(freshNdjson.status).toBe(200);
+        expect(freshNdjson.headers['content-type']).toContain(
+          'application/x-ndjson',
+        );
+        const freshNdjsonRows = freshNdjson.text
+          .split('\n')
+          .filter((line) => line.trim())
+          .map((line) => JSON.parse(line));
+        expect(freshNdjsonRows.map((row) => row.date)).toEqual(expectedDates);
+        expect(freshNdjsonRows.map((row) => row.total)).toEqual([42, 84]);
+
+        const freshCsv = await httpReqRaw({
+          method: 'GET',
+          url: buildDaDataUrl(
+            baseUrl,
+            servicePath,
+            fdaSerializationId,
+            daSerializationId,
+            { fresh: true },
+          ),
+          headers: {
+            'Fiware-Service': service,
+            Accept: 'text/csv',
+          },
+        });
+
+        expect(freshCsv.status).toBe(200);
+        expect(freshCsv.headers['content-type']).toContain('text/csv');
+        expect(freshCsv.text).toContain(expectedDates[0]);
+        expect(freshCsv.text).toContain(expectedDates[1]);
+        expect(freshCsv.text).not.toContain('[object Object]');
+      } finally {
+        await pgClient.query(`DROP TABLE IF EXISTS public.${fixtureTable}`);
+        await pgClient.end();
+      }
     });
 
     test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data rejects invalid fresh query param', async () => {

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -2943,6 +2943,170 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(res.buffer.length).toBeGreaterThan(100);
     });
 
+    test('POST /plugin/cda/api/doQuery serializes dates consistently for json/csv/xls', async () => {
+      const fixtureTable = 'cda_format_serialization_fixture';
+      const cdaFdaId = 'fda_cda_serialization_regression';
+      const cdaDaId = 'da_cda_serialization_regression';
+      const expectedDates = [
+        '2024-01-10T12:34:56.789Z',
+        '2024-01-11T08:15:30.123Z',
+      ];
+
+      const pgClient = new Client({
+        host: pgHost,
+        port: pgPort,
+        user: 'postgres',
+        password: 'postgres',
+        database: service,
+      });
+
+      await connectWithRetry(pgClient);
+
+      try {
+        await pgClient.query(`DROP TABLE IF EXISTS public.${fixtureTable}`);
+        await pgClient.query(`
+          CREATE TABLE public.${fixtureTable} (
+            id INT PRIMARY KEY,
+            observed_at TIMESTAMPTZ NOT NULL,
+            total_bigint BIGINT NOT NULL,
+            note TEXT
+          )
+        `);
+        await pgClient.query(
+          `
+            INSERT INTO public.${fixtureTable} (id, observed_at, total_bigint, note)
+            VALUES
+              (1, $1::timestamptz, 42, 'alpha'),
+              (2, $2::timestamptz, 84, 'with,comma')
+          `,
+          expectedDates,
+        );
+
+        const createFda = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+          body: {
+            id: cdaFdaId,
+            description: 'cda serialization regression fda',
+            query: `
+              SELECT
+                id,
+                observed_at AS date,
+                total_bigint AS total,
+                note
+              FROM public.${fixtureTable}
+              ORDER BY id
+            `,
+          },
+        });
+
+        expect(createFda.status).toBe(202);
+
+        await waitUntilFDACompleted({
+          baseUrl,
+          service,
+          fdaId: cdaFdaId,
+        });
+
+        const createDa = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas/${cdaFdaId}/das`,
+          headers: { 'Fiware-Service': service },
+          body: {
+            id: cdaDaId,
+            description: 'cda serialization regression da',
+            query: `
+              SELECT date, total, note
+              ORDER BY date
+            `,
+          },
+        });
+
+        expect(createDa.status).toBe(201);
+
+        const jsonRes = await httpFormReq({
+          method: 'POST',
+          url: `${baseUrl}/plugin/cda/api/doQuery`,
+          headers: { 'Fiware-Service': service },
+          form: {
+            path: `/public/${service}/verticals/sql/${cdaDaId}`,
+            cda: cdaFdaId,
+            dataAccessId: cdaDaId,
+            pageSize: '10',
+            pageStart: '0',
+          },
+        });
+
+        expect(jsonRes.status).toBe(200);
+        expect(Array.isArray(jsonRes.json.metadata)).toBe(true);
+        expect(Array.isArray(jsonRes.json.resultset)).toBe(true);
+
+        const dateColIndex = jsonRes.json.metadata.findIndex(
+          (col) => col.colName === 'date',
+        );
+        const totalColIndex = jsonRes.json.metadata.findIndex(
+          (col) => col.colName === 'total',
+        );
+
+        expect(dateColIndex).toBeGreaterThanOrEqual(0);
+        expect(totalColIndex).toBeGreaterThanOrEqual(0);
+        expect(jsonRes.json.resultset.map((row) => row[dateColIndex])).toEqual(
+          expectedDates,
+        );
+        expect(
+          jsonRes.json.resultset.every((row) =>
+            ['string', 'number'].includes(typeof row[totalColIndex]),
+          ),
+        ).toBe(true);
+
+        const csvRes = await httpReqRaw({
+          method: 'POST',
+          url: `${baseUrl}/plugin/cda/api/doQuery`,
+          headers: { 'Fiware-Service': service },
+          form: {
+            path: `/public/${service}/verticals/sql/${cdaDaId}`,
+            cda: cdaFdaId,
+            dataAccessId: cdaDaId,
+            outputType: 'csv',
+          },
+        });
+
+        expect(csvRes.status).toBe(200);
+        expect(csvRes.headers['content-type']).toContain('text/csv');
+        expect(csvRes.text).toContain(expectedDates[0]);
+        expect(csvRes.text).toContain(expectedDates[1]);
+        expect(csvRes.text).not.toContain('[object Object]');
+
+        const xlsRes = await httpReqRaw({
+          method: 'POST',
+          url: `${baseUrl}/plugin/cda/api/doQuery`,
+          headers: { 'Fiware-Service': service },
+          form: {
+            path: `/public/${service}/verticals/sql/${cdaDaId}`,
+            cda: cdaFdaId,
+            dataAccessId: cdaDaId,
+            outputType: 'xls',
+          },
+        });
+
+        expect(xlsRes.status).toBe(200);
+        expect(xlsRes.headers['content-type']).toContain(
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        );
+        expect(xlsRes.headers['content-disposition']).toContain('results.xlsx');
+        expect(xlsRes.buffer[0]).toBe(0x50);
+        expect(xlsRes.buffer[1]).toBe(0x4b);
+        expect(xlsRes.buffer.length).toBeGreaterThan(100);
+      } finally {
+        await pgClient.query(`DROP TABLE IF EXISTS public.${fixtureTable}`);
+        await pgClient.end();
+      }
+    });
+
     test('POST /plugin/cda/api/doQuery rejects unsupported outputType', async () => {
       const res = await httpFormReq({
         method: 'POST',

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -215,6 +215,27 @@ describe('fda fresh query execution', () => {
     expect(rows).toEqual([{ id: 7 }]);
   });
 
+  test('serializes Date values as ISO strings in fresh JSON results', async () => {
+    mongoMocks.retrieveDA.mockResolvedValue({
+      query: 'SELECT id',
+      params: {},
+    });
+
+    pgMocks.runPgQuery.mockResolvedValue([
+      { date: new Date('2026-04-08T10:11:12.000Z'), count: 1n },
+    ]);
+
+    const rows = await executeQuery({
+      service: 'svc',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      params: { fdaId: 'fdaA', daId: 'daA' },
+      fresh: true,
+    });
+
+    expect(rows).toEqual([{ date: '2026-04-08T10:11:12.000Z', count: 1 }]);
+  });
+
   test('throws DaNotFound when DA does not exist', async () => {
     mongoMocks.retrieveDA.mockResolvedValue(undefined);
 
@@ -618,6 +639,111 @@ describe('fda fresh query execution', () => {
         fresh: true,
       }),
     ).rejects.toBe(streamError);
+  });
+
+  test('serializes DuckDB timestamp micros in non-fresh NDJSON stream', async () => {
+    const { req, res } = createReqRes();
+    const conn = {};
+    const stream = {
+      columnNames: jest.fn().mockReturnValue(['date', 'count']),
+      fetchChunk: jest
+        .fn()
+        .mockResolvedValueOnce({
+          rowCount: 1,
+          getRows: () => [[{ micros: 1700524800000000 }, 1n]],
+        })
+        .mockResolvedValueOnce({ rowCount: 0, getRows: () => [] }),
+    };
+    const close = jest.fn().mockResolvedValue(undefined);
+
+    dbMocks.getDBConnection.mockResolvedValue(conn);
+    dbMocks.runPreparedStatementStream.mockResolvedValue({ stream, close });
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      status: 'completed',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      lastFetch: new Date('2026-04-08T00:00:00.000Z').toISOString(),
+    });
+
+    await executeQueryStream({
+      service: 'svc',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      params: { fdaId: 'fdaA', daId: 'daA' },
+      req,
+      res,
+      fresh: false,
+    });
+
+    expect(res.write).toHaveBeenCalledWith(
+      '{"date":"2023-11-21T00:00:00.000Z","count":1}\n',
+    );
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(dbMocks.releaseDBConnection).toHaveBeenCalledWith(conn);
+  });
+
+  test('serializes DuckDB timestamp micros in non-fresh CSV stream', async () => {
+    const { req, res } = createReqRes();
+    const conn = {};
+    const stream = {
+      columnNames: jest.fn().mockReturnValue(['date']),
+      fetchChunk: jest
+        .fn()
+        .mockResolvedValueOnce({
+          rowCount: 1,
+          getRows: () => [[{ micros: 1700524800000000 }]],
+        })
+        .mockResolvedValueOnce({ rowCount: 0, getRows: () => [] }),
+    };
+    const close = jest.fn().mockResolvedValue(undefined);
+
+    dbMocks.getDBConnection.mockResolvedValue(conn);
+    dbMocks.runPreparedStatementStream.mockResolvedValue({ stream, close });
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      status: 'completed',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      lastFetch: new Date('2026-04-08T00:00:00.000Z').toISOString(),
+    });
+
+    await executeQueryCsvStream({
+      service: 'svc',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      params: { fdaId: 'fdaA', daId: 'daA' },
+      req,
+      res,
+      fresh: false,
+    });
+
+    expect(res.write).toHaveBeenNthCalledWith(1, 'date\n');
+    expect(res.write).toHaveBeenNthCalledWith(2, '2023-11-21T00:00:00.000Z\n');
+  });
+
+  test('serializes DuckDB timestamp micros in non-fresh JSON results', async () => {
+    const conn = {};
+
+    dbMocks.getDBConnection.mockResolvedValue(conn);
+    dbMocks.runPreparedStatement.mockResolvedValue([
+      { date: { micros: 1700524800000000 }, count: 1n },
+    ]);
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      status: 'completed',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      lastFetch: new Date('2026-04-08T00:00:00.000Z').toISOString(),
+    });
+
+    const rows = await executeQuery({
+      service: 'svc',
+      visibility: 'private',
+      servicePath: '/servicepath',
+      params: { fdaId: 'fdaA', daId: 'daA' },
+      fresh: false,
+    });
+
+    expect(rows).toEqual([{ date: '2023-11-21T00:00:00.000Z', count: 1 }]);
+    expect(dbMocks.releaseDBConnection).toHaveBeenCalledWith(conn);
   });
 });
 

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -133,7 +133,6 @@ await jest.unstable_mockModule('../../src/lib/fdaConfig.js', () => ({
 const {
   executeQuery,
   executeQueryStream,
-  executeQueryCsvStream,
   fetchFDA,
   getFDA,
   updateFDA,
@@ -463,7 +462,7 @@ describe('fda fresh query execution', () => {
     };
     pgMocks.createPgCursorReader.mockResolvedValue(cursorReader);
 
-    await executeQueryCsvStream({
+    await executeQueryStream({
       service: 'svc',
       visibility: 'private',
       servicePath: '/servicepath',
@@ -471,6 +470,7 @@ describe('fda fresh query execution', () => {
       req,
       res,
       fresh: true,
+      format: 'csv',
     });
 
     expect(res.setHeader).toHaveBeenCalledWith(
@@ -509,7 +509,7 @@ describe('fda fresh query execution', () => {
       lastFetch: new Date('2026-04-08T00:00:00.000Z').toISOString(),
     });
 
-    await executeQueryCsvStream({
+    await executeQueryStream({
       service: 'svc',
       visibility: 'private',
       servicePath: '/servicepath',
@@ -517,6 +517,7 @@ describe('fda fresh query execution', () => {
       req,
       res,
       fresh: false,
+      format: 'csv',
     });
 
     expect(res.write).toHaveBeenNthCalledWith(1, 'a,b,c\n');
@@ -550,7 +551,7 @@ describe('fda fresh query execution', () => {
       lastFetch: new Date('2026-04-08T00:00:00.000Z').toISOString(),
     });
 
-    await executeQueryCsvStream({
+    await executeQueryStream({
       service: 'svc',
       visibility: 'private',
       servicePath: '/servicepath',
@@ -558,6 +559,7 @@ describe('fda fresh query execution', () => {
       req,
       res,
       fresh: false,
+      format: 'csv',
     });
 
     expect(res.once).toHaveBeenCalledWith('drain', expect.any(Function));
@@ -581,7 +583,7 @@ describe('fda fresh query execution', () => {
     });
 
     await expect(
-      executeQueryCsvStream({
+      executeQueryStream({
         service: 'svc',
         visibility: 'private',
         servicePath: '/servicepath',
@@ -589,6 +591,7 @@ describe('fda fresh query execution', () => {
         req,
         res,
         fresh: false,
+        format: 'csv',
       }),
     ).rejects.toThrow('stream init failed');
 
@@ -706,7 +709,7 @@ describe('fda fresh query execution', () => {
       lastFetch: new Date('2026-04-08T00:00:00.000Z').toISOString(),
     });
 
-    await executeQueryCsvStream({
+    await executeQueryStream({
       service: 'svc',
       visibility: 'private',
       servicePath: '/servicepath',
@@ -714,6 +717,7 @@ describe('fda fresh query execution', () => {
       req,
       res,
       fresh: false,
+      format: 'csv',
     });
 
     expect(res.write).toHaveBeenNthCalledWith(1, 'date\n');

--- a/test/unit/freshQueriesHelpers.test.js
+++ b/test/unit/freshQueriesHelpers.test.js
@@ -55,6 +55,20 @@ describe('fresh query helpers', () => {
     });
   });
 
+  test('normalizeForSerialization converts Date and DuckDB micros timestamps', () => {
+    const payload = {
+      createdAt: new Date('2026-04-08T10:11:12.000Z'),
+      duckdbDate: { micros: 1700524800000000 },
+      duckdbTimestampString: '2024-01-10 14:34:56.789+02',
+    };
+
+    expect(normalizeForSerialization(payload)).toEqual({
+      createdAt: '2026-04-08T10:11:12.000Z',
+      duckdbDate: '2023-11-21T00:00:00.000Z',
+      duckdbTimestampString: '2024-01-10T12:34:56.789Z',
+    });
+  });
+
   test('validateAllowedFieldsBody throws when body includes invalid fields', () => {
     expect(() =>
       validateAllowedFieldsBody({ query: 'SELECT 1', forbidden: true }, [

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -46,7 +46,6 @@ const fdaMocks = {
   fetchFDA: jest.fn(),
   executeQuery: jest.fn(),
   executeQueryStream: jest.fn(),
-  executeQueryCsvStream: jest.fn(),
   createDA: jest.fn(),
   getFDA: jest.fn(),
   updateFDA: jest.fn(),
@@ -103,12 +102,11 @@ function resetModuleMocks() {
   fdaMocks.getFDAs.mockReset().mockResolvedValue([]);
   fdaMocks.fetchFDA.mockReset().mockResolvedValue(undefined);
   fdaMocks.executeQuery.mockReset().mockResolvedValue([{ ok: true }]);
-  fdaMocks.executeQueryStream.mockReset().mockImplementation(({ res }) => {
-    res.status(200).send('streamed');
-  });
-  fdaMocks.executeQueryCsvStream.mockReset().mockImplementation(({ res }) => {
-    res.status(200).send('streamed-csv');
-  });
+  fdaMocks.executeQueryStream
+    .mockReset()
+    .mockImplementation(({ res, format }) => {
+      res.status(200).send(format === 'csv' ? 'streamed-csv' : 'streamed');
+    });
   fdaMocks.createDA.mockReset().mockResolvedValue(undefined);
   fdaMocks.getFDA.mockReset().mockResolvedValue({ fdaId: 'fda1' });
   fdaMocks.updateFDA.mockReset().mockResolvedValue(undefined);
@@ -257,7 +255,6 @@ async function loadIndexModule({
     fetchFDA: fdaMocks.fetchFDA,
     executeQuery: fdaMocks.executeQuery,
     executeQueryStream: fdaMocks.executeQueryStream,
-    executeQueryCsvStream: fdaMocks.executeQueryCsvStream,
     assertFDAAccess: jest.fn(),
     createDA: fdaMocks.createDA,
     getFDA: fdaMocks.getFDA,
@@ -883,7 +880,6 @@ describe('index routes - validation and middleware branches', () => {
     });
     expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
     expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
-    expect(fdaMocks.executeQueryCsvStream).not.toHaveBeenCalled();
   });
 
   test('defaults to JSON when no Accept header is sent', async () => {
@@ -898,7 +894,6 @@ describe('index routes - validation and middleware branches', () => {
     expect(res.body).toEqual([{ col: 1 }]);
     expect(fdaMocks.executeQuery).toHaveBeenCalled();
     expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
-    expect(fdaMocks.executeQueryCsvStream).not.toHaveBeenCalled();
   });
 
   test('defaults to JSON when Accept is */*', async () => {
@@ -914,7 +909,6 @@ describe('index routes - validation and middleware branches', () => {
     expect(res.body).toEqual([{ col: 2 }]);
     expect(fdaMocks.executeQuery).toHaveBeenCalled();
     expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
-    expect(fdaMocks.executeQueryCsvStream).not.toHaveBeenCalled();
   });
 
   test('routes to CSV streaming when Accept is text/*', async () => {
@@ -925,9 +919,10 @@ describe('index routes - validation and middleware branches', () => {
       .set('Accept', 'text/*')
       .expect(200);
 
-    expect(fdaMocks.executeQueryCsvStream).toHaveBeenCalled();
+    expect(fdaMocks.executeQueryStream).toHaveBeenCalledWith(
+      expect.objectContaining({ format: 'csv' }),
+    );
     expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
-    expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
   });
 
   test('uses q-value priority: skips unsupported type and picks ndjson over json', async () => {
@@ -940,7 +935,9 @@ describe('index routes - validation and middleware branches', () => {
 
     expect(fdaMocks.executeQueryStream).toHaveBeenCalled();
     expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
-    expect(fdaMocks.executeQueryCsvStream).not.toHaveBeenCalled();
+    expect(fdaMocks.executeQueryStream).toHaveBeenCalledWith(
+      expect.not.objectContaining({ format: 'csv' }),
+    );
   });
 
   test('routes to xls when Accept is application/vnd.ms-excel', async () => {
@@ -969,12 +966,13 @@ describe('index routes - validation and middleware branches', () => {
       .expect(200);
 
     expect(res.text).toBe('streamed-csv');
-    expect(fdaMocks.executeQueryCsvStream).toHaveBeenCalledWith(
+    expect(fdaMocks.executeQueryStream).toHaveBeenCalledWith(
       expect.objectContaining({
         service: 'svc',
         visibility: 'public',
         servicePath: '/servicepath',
         fresh: false,
+        format: 'csv',
       }),
     );
     expect(fdaMocks.executeQuery).not.toHaveBeenCalled();


### PR DESCRIPTION
**Follow-up to #138 — closes #137**

This PR addresses a serialization bug that was left uncovered in #138: date fields in not fresh NDJSON. The fix centralizes normalization for both DuckDB and PostgreSQL execution paths so output is consistent across all formats and modes.

Additionally, this includes a refactor that was pending.

Finally, integration tests for the legacy `doQuery` path have been added (json/csv/xls with date fixture), mirroring the format-matrix regression tests added in #138 for the main data endpoint.