### PR TITLE
Update bucket name convention

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,6 +4,7 @@
 - Fix: value of default params are checked when creating DA (#107)
 - Fix: query operation is now REST-like using `GET /{visibility}/fdas/{fdaId}/das/{daId}/data` instead of `/query` (#62)
 - Add: visibility-based data access segmentation (`public` / `private`) with FDA visibility validation, including CDA `doQuery` compatibility path handling (#21)
+- Fix: object storage bucket name is now derived from `Fiware-Service` by replacing `_` with `-` (hard change); potential bucket-name collisions are an accepted restriction (#140)
 - Fix: `fresh=true` queries now serialize dates as ISO 8601 strings and integers as numbers consistently with the cached Parquet path, across JSON, NDJSON and CSV outputs (#137)
 - Fix: format negotiation done using the `Accept` HTTP standard mechanism (outputType is no longer supported, except in the Pentaho legacy operation) (#137)
 - Fix: FDA now includes `servicePath` in Mongo unique index (`service + servicePath + fdaId`) and operational storage layout is now scoped as `/service/servicePath/fdaId/` (#132)

--- a/doc/05_advanced_topics.md
+++ b/doc/05_advanced_topics.md
@@ -18,10 +18,19 @@ topics related to this system.
 ### Bucket name convention
 
 When creating a _FDA_ we fetch the data from `PostgreSQL` and store inside a _bucket_ in our storage system. The name of
-this _bucket_ is fixed and is the **same** as the `fiware-service` of the _FDA_. \
+this _bucket_ is fixed and derived from the `fiware-service` of the _FDA_, replacing `_` with `-`. \
 The `FDA` app **does not** create the bucket when uploading a _FDA_ to the object bucket-based storage system, it instead
 rises an error. This is because we want to manage the bucket permissions so we prefer to create the bucket previously by
 hand.
+
+Current naming convention:
+
+| service        | bucket name    |
+| -------------- | -------------- |
+| `service_name` | `service-name` |
+
+Known restriction: bucket name normalization can generate collisions (for example `service_name` and `service-name` map
+to the same bucket). This restriction is currently accepted.
 
 ### File name convention
 

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -63,6 +63,7 @@ import {
 } from './utils/utils.js';
 import {
   buildFDAJobFilter,
+  getBucketNameFromService,
   getFDAStoragePath,
   normalizeScopedServicePath,
 } from './utils/fdaScope.js';
@@ -792,6 +793,7 @@ export async function processFDAAsync(
   partitionFlag,
 ) {
   const storagePath = getFDAStoragePath(fdaId, servicePath);
+  const bucketName = getBucketNameFromService(service);
 
   try {
     await updateFDAStatus(service, fdaId, servicePath, 'fetching', 10);
@@ -800,7 +802,7 @@ export async function processFDAAsync(
       service,
       service,
       query,
-      service,
+      bucketName,
       storagePath,
       fdaId,
       servicePath,
@@ -840,6 +842,7 @@ export async function deleteFDA(service, fdaId, visibility, servicePath) {
       `FDA ${fdaId} of the service ${service} not found.`,
     );
   }
+  const bucketName = getBucketNameFromService(service);
   const s3Client = await getS3Client(
     `${config.objstg.protocol}://${config.objstg.endpoint}`,
     config.objstg.usr,
@@ -848,10 +851,10 @@ export async function deleteFDA(service, fdaId, visibility, servicePath) {
   // This way we remove FDAs independently of if theyre partitioned or not
   const objPaths = await listObjects(
     s3Client,
-    service,
+    bucketName,
     getFDAStoragePath(fdaId, targetServicePath),
   );
-  await dropFiles(s3Client, service, objPaths);
+  await dropFiles(s3Client, bucketName, objPaths);
 
   await removeFDA(service, fdaId, targetServicePath);
 
@@ -964,11 +967,12 @@ export async function cleanPartition(
     config.objstg.usr,
     config.objstg.pass,
   );
+  const bucketName = getBucketNameFromService(service);
 
   /* c8 ignore next 6 */
   const objPaths = await listObjects(
     s3Client,
-    service,
+    bucketName,
     getFDAStoragePath(fdaId, servicePath),
   );
 
@@ -980,7 +984,7 @@ export async function cleanPartition(
       partitionsToRemove.push(path);
     }
   }
-  await dropFiles(s3Client, service, partitionsToRemove);
+  await dropFiles(s3Client, bucketName, partitionsToRemove);
 }
 
 async function uploadTableToObjStg(
@@ -1199,15 +1203,20 @@ async function createOneRowParquetSync(service, fdaId, query, servicePath) {
     config.objstg.pass,
   );
   const storagePath = getFDAStoragePath(fdaId, servicePath);
+  const bucketName = getBucketNameFromService(service);
 
   const oneRowQuery = buildOneRowQuery(query);
-  await uploadTable(s3Client, service, service, oneRowQuery, storagePath);
+  await uploadTable(s3Client, bucketName, service, oneRowQuery, storagePath);
 
   const conn = await getDBConnection();
   try {
-    const parquetPath = getPath(service, storagePath, '.parquet');
-    await toParquet(conn, getPath(service, storagePath, '.csv'), parquetPath);
-    await dropFile(s3Client, service, `${storagePath}.csv`);
+    const parquetPath = getPath(bucketName, storagePath, '.parquet');
+    await toParquet(
+      conn,
+      getPath(bucketName, storagePath, '.csv'),
+      parquetPath,
+    );
+    await dropFile(s3Client, bucketName, `${storagePath}.csv`);
   } finally {
     await releaseDBConnection(conn);
   }
@@ -1225,10 +1234,11 @@ async function rollbackFDAProvisioning(service, fdaId, servicePath) {
     config.objstg.pass,
   );
   const storagePath = getFDAStoragePath(fdaId, servicePath);
+  const bucketName = getBucketNameFromService(service);
 
   await Promise.allSettled([
-    dropFile(s3Client, service, `${storagePath}.csv`),
-    dropFile(s3Client, service, `${storagePath}.parquet`),
+    dropFile(s3Client, bucketName, `${storagePath}.csv`),
+    dropFile(s3Client, bucketName, `${storagePath}.parquet`),
     removeFDA(service, fdaId, servicePath),
   ]);
 }

--- a/src/lib/utils/db.js
+++ b/src/lib/utils/db.js
@@ -26,7 +26,7 @@ import { retrieveDA, retrieveFDA } from './mongo.js';
 import { FDAError } from '../fdaError.js';
 import { getBasicLogger } from './logger.js';
 import { config } from '../fdaConfig.js';
-import { getFDAStoragePath } from './fdaScope.js';
+import { getBucketNameFromService, getFDAStoragePath } from './fdaScope.js';
 
 let instance = null;
 
@@ -556,7 +556,8 @@ export function buildDAQuery(
   const trimmed = userQuery.trim();
 
   const objectKey = getFDAStoragePath(fdaId, servicePath);
-  const parquetPath = `s3://${service}/${objectKey}.parquet`;
+  const bucketName = getBucketNameFromService(service);
+  const parquetPath = `s3://${bucketName}/${objectKey}.parquet`;
 
   if (partition) {
     return `FROM read_parquet('${parquetPath}/**/*.parquet') ${trimmed}`;

--- a/src/lib/utils/fdaScope.js
+++ b/src/lib/utils/fdaScope.js
@@ -47,6 +47,14 @@ export function getFDAStoragePath(fdaId, servicePath) {
   return `${servicePathScope}/${fdaId}`;
 }
 
+export function getBucketNameFromService(service) {
+  if (!service || typeof service !== 'string') {
+    throw new Error('service is required');
+  }
+
+  return service.replace(/_/g, '-');
+}
+
 export function buildFDAJobFilter(name, service, fdaId, servicePath) {
   return {
     name,

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -331,6 +331,22 @@ describe('db utils', () => {
     );
   });
 
+  test('buildDAQuery normalizes bucket name from service with underscores', async () => {
+    const { buildDAQuery } = await loadDbModule();
+
+    const result = buildDAQuery(
+      'service_name',
+      'fdaA',
+      'SELECT * WHERE id = $1',
+      false,
+      '/servicepath',
+    );
+
+    expect(result).toBe(
+      "FROM read_parquet('s3://service-name/servicepath/fdaA.parquet') SELECT * WHERE id = $1",
+    );
+  });
+
   test('resolveDAParams coerces boolean string values', async () => {
     const { resolveDAParams } = await loadDbModule();
 

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -1072,6 +1072,18 @@ describe('processFDAAsync', () => {
     );
   });
 
+  test('uses normalized bucket name while preserving original database name', async () => {
+    await processFDAAsync('fda1', 'SELECT 1', 'service_name', '/servicepath');
+
+    expect(pgMocks.uploadTable).toHaveBeenCalledWith(
+      {},
+      'service-name',
+      'service_name',
+      'SELECT 1',
+      'servicepath/fda1',
+    );
+  });
+
   test('marks FDA as failed and rethrows when upload fails', async () => {
     pgMocks.uploadTable.mockRejectedValue(new Error('upload failed'));
 
@@ -1128,6 +1140,26 @@ describe('deleteFDA', () => {
       'data.fdaId': 'fdaA',
       'data.servicePath': '/servicepath',
     });
+  });
+
+  test('deleteFDA uses normalized bucket name for object storage deletion', async () => {
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      _id: 'mongo-id',
+      visibility: 'private',
+      servicePath: '/servicepath',
+    });
+    awsMocks.listObjects.mockResolvedValue(['routeTo/fdaA.parquet']);
+
+    await deleteFDA('service_name', 'fdaA', 'private', '/servicepath');
+
+    expect(awsMocks.listObjects).toHaveBeenCalledWith(
+      {},
+      'service-name',
+      'servicepath/fdaA',
+    );
+    expect(awsMocks.dropFiles).toHaveBeenCalledWith({}, 'service-name', [
+      'routeTo/fdaA.parquet',
+    ]);
   });
 
   test('throws FDANotFound when FDA does not exist', async () => {
@@ -1570,6 +1602,25 @@ describe('cleanPartition', () => {
     expect(awsMocks.dropFiles).toHaveBeenCalledWith({}, 'svc', [
       'svc/fdaA/2020-01-01.parquet',
     ]);
+  });
+
+  test('cleanPartition uses normalized bucket name in object storage calls', async () => {
+    dbMocks.extractDate.mockReturnValue(new Date('2099-01-01'));
+
+    await cleanPartition(
+      'service_name',
+      'fdaA',
+      'month',
+      { partition: true },
+      '/public',
+    );
+
+    expect(awsMocks.listObjects).toHaveBeenCalledWith(
+      {},
+      'service-name',
+      'public/fdaA',
+    );
+    expect(awsMocks.dropFiles).toHaveBeenCalledWith({}, 'service-name', []);
   });
 
   test('calls dropFiles with empty array when no partitions are older than cutoff', async () => {

--- a/test/unit/fdaScope.test.js
+++ b/test/unit/fdaScope.test.js
@@ -24,6 +24,7 @@
 
 import { describe, expect, test } from '@jest/globals';
 import {
+  getBucketNameFromService,
   normalizeScopedServicePath,
   getFDAStoragePath,
 } from '../../src/lib/utils/fdaScope.js';
@@ -47,5 +48,15 @@ describe('fdaScope utils', () => {
 
   test('getFDAStoragePath builds scoped path for non-root servicePath', () => {
     expect(getFDAStoragePath('fdaA', '/public')).toBe('public/fdaA');
+  });
+
+  test('getBucketNameFromService replaces underscores with hyphens', () => {
+    expect(getBucketNameFromService('service_name')).toBe('service-name');
+  });
+
+  test('getBucketNameFromService allows collisions as documented restriction', () => {
+    expect(getBucketNameFromService('service_name')).toBe(
+      getBucketNameFromService('service-name'),
+    );
   });
 });


### PR DESCRIPTION
This PR updates bucket naming to derive from Fiware-Service by replacing `_` with `-` across storage read/write/delete flows.

## Notes
- Breaking change: no backward migration for previous bucket names.
- Known limitation: name collisions are accepted (e.g. `service_name` and `service-name`).

Related Issue: #140 