### PR TITLE
Unify refreshPolicy types interval and cron

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Remove: refreshPolicy type cron removed in favor of using only refreshPolicy type onterval (#143)
 - Add: observability in health endpoint and Prometheus/OpenMetrics metrics endpoint `GET /metrics` (#90)
 - Add: postgres db connection pool and env vars (`FDA_PG_POOL_MAX`, `FDA_PG_POOL_IDLE_TIMEOUT_MS`, `FDA_PG_POOL_CONN_TIMEOUT_MS`, `FDA_PG_POOL_DB_IDLE_TIMEOUT_MS`) (#28)
 - Add: response format selection in query and doQuery using outputType, with csv and xls support (#20)

--- a/doc/02_architecture.md
+++ b/doc/02_architecture.md
@@ -17,7 +17,7 @@ An **FDA** represents a **materialized dataset** in the system. It:
 -   Stores the result as a **Parquet file**
 -   Saves the file in a **bucket-based object storage system**
 -   Acts as the **base dataset** for one or more DAs
--   Supports an optional `refreshPolicy` that defines how the FDA is automatically refreshed (none, interval, or cron)
+-   Supports an optional `refreshPolicy` that defines how the FDA is automatically refreshed (none, interval or window)
 
 In simple terms:
 
@@ -48,7 +48,7 @@ Content-Type: application/json
     "description": "All animal activity records",
     "query": "SELECT * FROM animal_activity",
     "refreshPolicy": {
-        "type": "cron",
+        "type": "interval",
         "value": "0 * * * *"
     }
 }
@@ -142,7 +142,7 @@ Each document corresponds to one FDA:
 -   **description**: FDA description
 -   **query**: SQL query used to generate the Parquet file
 -   **das**: keymap of DAs associated with the FDA
--   **refreshPolicy**: object defining automatic refresh behaviour (`none`, `interval`, or `cron`)
+-   **refreshPolicy**: object defining automatic refresh behaviour (`none`, `interval`, or `window`)
 -   **status**: current execution status (`fetching`, `transforming`, `uploading`, `completed`, `failed`)
 -   **progress**: execution progress percentage (0–100)
 -   **lastFetch**: timestamp of the last fetch (ISO date)

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -486,10 +486,10 @@ A FDA is represented by a JSON object with the following fields:
 
 Defines how and when the FDA should be automatically refreshed.
 
-| Field               | Optional | Type   | Description                                                     |
-| ------------------- | -------- | ------ | --------------------------------------------------------------- |
-| `type`              |          | string | Refresh strategy. One of: `none`, `interval`, `cron`, `window`. |
-| [`params`](#params) | (\*)     | object | Object with the parameters for the refresh policy type.         |
+| Field               | Optional | Type   | Description                                             |
+| ------------------- | -------- | ------ | ------------------------------------------------------- |
+| `type`              |          | string | Refresh strategy. One of: `none`, `interval`, `window`. |
+| [`params`](#params) | (\*)     | object | Object with the parameters for the refresh policy type. |
 
 (\*) Not used when `type` is `none`, mandatory otherwise
 

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -623,7 +623,7 @@ export async function fetchFDA(
   });
 
   // Schedule refreshes according to policy
-  if (refreshPolicy?.type === 'interval' || refreshPolicy?.type === 'cron') {
+  if (refreshPolicy?.type === 'interval') {
     const { refreshInterval, windowSize } = refreshPolicy.params || {};
 
     // unique is not really needed since we check existence before, but it adds an extra layer of safety in case of duplicate calls

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -1349,7 +1349,7 @@ describe('fetchFDA with refresh policies', () => {
     agenda.every.mockResolvedValue(undefined);
   });
 
-  test('fetchFDA with cron refresh policy schedules periodic job', async () => {
+  test('fetchFDA with interval refresh policy schedules periodic job', async () => {
     await fetchFDA(
       'fda1',
       'SELECT 1',
@@ -1358,7 +1358,7 @@ describe('fetchFDA with refresh policies', () => {
       '/servicepath',
       'desc',
       {
-        type: 'cron',
+        type: 'interval',
         params: { refreshInterval: '0 0 * * *' },
       },
       'timeinstant',


### PR DESCRIPTION
#143
Right now refreshPolicy types `interval` and `cron` where the same, both took a `refreshInterval` in cron expression or Agenda human readable format.
That was confusing so we unified both under the `interval` type.
