### PR TITLE
Implementation of defaultDataAccess

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@
 FDA_NODE_ENV=development
 FDA_SERVER_PORT=8080
 
+# Create default data access
+FDA_CREATE_DEFAULT_DATA_ACCESS=true
+
 # Instance Roles
 FDA_ROLE_APISERVER=true
 FDA_ROLE_FETCHER=true

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
-- Fix POST api (FDA, DA) without body to avoid internal server error
+- Fix: POST api (FDA, DA) without body to avoid internal server error
+- Add: automatic `defaultDataAccess` creation on FDA creation, with optional column filters, `start`/`finish`, and `limit`/`offset` support in cached mode (#133)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - Fix: POST api (FDA, DA) without body to avoid internal server error
 - Add: automatic `defaultDataAccess` creation on FDA creation, with optional column filters, `start`/`finish`, and `limit`/`offset` support in cached mode (#133)
+- Add: `FDA_CREATE_DEFAULT_DATA_ACCESS` env var to configure the instance default for automatic `defaultDataAccess` creation (#133)

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -543,9 +543,7 @@ _**Request path parameters**_
 
 _**Request query parameters**_
 
-| Parameter           | Optional | Description                                                                                                 | Example |
-| ------------------- | -------- | ----------------------------------------------------------------------------------------------------------- | ------- |
-| `defaultDataAccess` | ✓        | Overrides the instance default and enables or disables automatic `defaultDataAccess` creation for this FDA. | `false` |
+None so far
 
 _**Request headers**_
 
@@ -613,7 +611,9 @@ _**Request path parameters**_
 
 _**Request query parameters**_
 
-None so far
+| Parameter           | Optional | Description                                                                                                                                                                                                                      | Example |
+| ------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `defaultDataAccess` | ✓        | Overrides the instance default and enables or disables automatic `defaultDataAccess` creation for this FDA. The default value is taken from `FDA_CREATE_DEFAULT_DATA_ACCESS`; if that env var is not set, the default is `true`. | `false` |
 
 _**Request headers**_
 

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -543,7 +543,9 @@ _**Request path parameters**_
 
 _**Request query parameters**_
 
-None so far
+| Parameter           | Optional | Description                                                                                                 | Example |
+| ------------------- | -------- | ----------------------------------------------------------------------------------------------------------- | ------- |
+| `defaultDataAccess` | ✓        | Overrides the instance default and enables or disables automatic `defaultDataAccess` creation for this FDA. | `false` |
 
 _**Request headers**_
 
@@ -639,6 +641,20 @@ curl -i -X POST http://localhost:8080/public/fdas \
     "description": "FDA de alarmas del sistema",
     "refreshPolicy": { "type": "interval", "value": "1 hour" }
   }'
+```
+
+_**Example Request disabling default DA:**_
+
+```bash
+curl -i -X POST "http://localhost:8080/public/fdas?defaultDataAccess=false" \
+    -H "Content-Type: application/json" \
+    -H "Fiware-Service: my-bucket" \
+    -H "Fiware-ServicePath: /servicePath" \
+    -d '{
+        "id": "fda_alarms_no_default",
+        "query": "SELECT * FROM public.alarms",
+        "description": "FDA without default DA"
+    }'
 ```
 
 _**Response code**_

--- a/doc/04_config_operational_guide.md
+++ b/doc/04_config_operational_guide.md
@@ -47,6 +47,7 @@ Variables that define which components of the application are executed by this i
 | `FDA_ROLE_FETCHER`                 | ✓        | boolean | If `true`, the instance runs the fetcher responsible for regenerating and updating FDAs. Default `true`.                                           |
 | `FDA_ROLE_SYNCQUERIES`             | ✓        | boolean | If `true`, the API instance accepts `fresh=true` queries and executes them directly against PostgreSQL. Default `false`.                           |
 | `FDA_MAX_CONCURRENT_FRESH_QUERIES` | ✓        | number  | Maximum number of concurrent `fresh=true` queries accepted by the API instance. Additional requests return `429 TooManyFreshQueries`. Default `5`. |
+| `FDA_CREATE_DEFAULT_DATA_ACCESS`   | ✓        | boolean | If `true`, FDA creation also creates a built-in `defaultDataAccess` DA unless the request overrides it. Default `true`.                            |
 
 > Note: By default, an instance runs both roles (API server and Fetcher). You can disable one to separate
 > responsibilities.
@@ -112,6 +113,7 @@ FDA_ROLE_APISERVER=true
 FDA_ROLE_FETCHER=true
 FDA_ROLE_SYNCQUERIES=true
 FDA_MAX_CONCURRENT_FRESH_QUERIES=5
+FDA_CREATE_DEFAULT_DATA_ACCESS=true
 
 # POSTGRESQL
 FDA_PG_USER=exampleUser

--- a/doc/05_advanced_topics.md
+++ b/doc/05_advanced_topics.md
@@ -14,6 +14,7 @@ topics related to this system.
 -   [Bucket name convention](#bucket-name-convention)
 -   [File name convention](#file-name-convention)
 -   [Data origin](#data-origin)
+-   [Default Data Access](#default-data-access)
 
 ### Bucket name convention
 
@@ -48,6 +49,20 @@ This object key is updated and removed in sync with the _fda_ information in `Mo
 
 When creating a _FDA_ we cannot specify the database from where we want to fetch the data. In _FDA_ we are always gonna
 use the `fiware-service` value as the _database_ name.
+
+### Default Data Access
+
+FDA can automatically create a built-in DA named `defaultDataAccess` when a new FDA is created.
+
+This topic covers:
+
+-   creation rules
+-   automatic optional filters
+-   `timeColumn` range support through `start` / `finish`
+-   pagination through `limit` / `offset`
+-   current `fresh=true` limitation for typeless optional filters
+
+Full documentation available at: [`Default Data Access`](/doc/AdvancedTopics/default_data_access.md)
 
 ---
 

--- a/doc/06_testing.md
+++ b/doc/06_testing.md
@@ -2,19 +2,25 @@
 
 ## Test Strategy
 
-This project relies on **end-to-end integration tests** rather than unit tests or mocks.
+This project uses a **mixed testing strategy**:
 
-The goal is to validate the full data flow across all external dependencies exactly as it runs in production.
+-   unit tests for isolated query-building, validation and error-path logic
+-   end-to-end integration tests for real cross-system behavior
+
+The goal is to validate both:
+
+-   deterministic internal logic close to the source of change
+-   the full data flow across external dependencies as it runs in production
 
 ---
 
 ### Approach
 
 -   Tests are written using **Jest**
--   The API is exercised using **real HTTP requests** (`supertest`)
--   No external services are mocked
+-   Unit tests use targeted mocks for isolated modules and edge cases
+-   Integration tests exercise the API using **real HTTP requests**
 
-Instead, tests start **real service instances** using Docker.
+Integration tests start **real service instances** using Docker.
 
 ---
 
@@ -63,33 +69,36 @@ The test flow is:
 
 ### What Is Tested
 
+Unit tests validate, among others:
+
+-   parameter validation and coercion
+-   DA/FDA query composition
+-   error propagation and cleanup behavior
+-   API route wiring and request validation
+
 Integration tests validate:
 
 -   FDA creation (PostgreSQL → CSV → Parquet → MinIO)
 -   Metadata persistence in MongoDB
 -   DuckDB query execution over Parquet files
 -   End-to-end API behavior using real data
-
----
-
-### Why No Unit Tests
-
-Unit tests and mocks are intentionally avoided because:
-
--   The core complexity lies in **integration between systems**
--   Mocking databases, S3, or DuckDB would not validate real behavior
--   The cost of integration testing is acceptable for this service
+-   `fresh=true` execution over PostgreSQL
+-   default DA behavior including automatic creation and optional filters
 
 ---
 
 ### Coverage Considerations
 
-Because the application runs as a **separate process**, standard Jest coverage:
+Because the application runs as a **separate process** in integration mode, standard Jest coverage:
 
 -   Does not instrument the application process
--   Only measures the test runner itself
+-   Under-reports integration-executed application code unless extra instrumentation is used
 
-Coverage can be collected using additional tooling (e.g. `c8`) if required, but is not enforced by default.
+Coverage can be collected using additional tooling (e.g. `c8`). In practice, meaningful coverage in this repository
+comes from combining:
+
+-   unit test execution inside the Jest process
+-   integration execution instrumented with external tooling
 
 ---
 

--- a/doc/AdvancedTopics/default_data_access.md
+++ b/doc/AdvancedTopics/default_data_access.md
@@ -1,0 +1,91 @@
+# Default Data Access
+
+## Overview
+
+When an FDA is created, the API can also create a built-in DA named `defaultDataAccess`.
+
+This DA is intended to provide an immediate, generic query surface for the whole FDA without requiring the client to
+manually define a first DA.
+
+## Creation rules
+
+Default DA creation is enabled by default and can be controlled in two ways:
+
+-   `FDA_CREATE_DEFAULT_DATA_ACCESS` environment variable defines the instance default behavior.
+-   `POST /{visibility}/fdas?defaultDataAccess=false` disables it for a specific FDA creation request.
+
+If enabled, the DA is created automatically after the one-row bootstrap parquet is generated and before the async fetch
+job is scheduled.
+
+## Atomic behavior
+
+FDA provisioning is atomic with respect to default DA creation.
+
+If default DA creation fails:
+
+-   bootstrap objects are removed
+-   the FDA metadata document is removed
+-   the whole `POST /fdas` operation fails
+
+This keeps the system from persisting partially provisioned FDAs.
+
+## Generated query shape
+
+The generated DA is persisted like any other DA. It can later be queried, updated or deleted through the regular DA API.
+
+The query follows this pattern:
+
+```sql
+SELECT *
+WHERE ($col1 IS NULL OR col1 = $col1)
+  AND ($col2 IS NULL OR col2 = $col2)
+LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT)
+OFFSET CAST(COALESCE($offset, 0) AS BIGINT)
+```
+
+Each FDA column gets one optional equality filter parameter with:
+
+-   `required: false` implicitly
+-   `default: null`
+-   no explicit `type`
+
+Parameter names are sanitized to alphanumeric and underscore format. If a generated name collides with reserved
+parameters, a numeric suffix is added.
+
+## Time range support
+
+If the FDA defines `timeColumn`, the generated DA also adds:
+
+-   `start`
+-   `finish`
+
+These are optional range filters applied to the FDA time column.
+
+Current generated predicate shape:
+
+```sql
+($start IS NULL OR CAST(timeColumn AS TIMESTAMP) >= CAST($start AS TIMESTAMP))
+($finish IS NULL OR CAST(timeColumn AS TIMESTAMP) <= CAST($finish AS TIMESTAMP))
+```
+
+## Pagination support
+
+Default DA also includes two optional pagination parameters:
+
+-   `limit`
+-   `offset`
+
+They are always present.
+
+## Current limitation in fresh mode
+
+The optional-filter pattern works correctly in cached mode over DuckDB/Parquet.
+
+However, it is currently not guaranteed to work in `fresh=true` mode over PostgreSQL for typeless optional parameters,
+particularly with predicates shaped as:
+
+```sql
+($p IS NULL OR col = $p)
+```
+
+This limitation is currently accepted and pending design discussion.

--- a/doc/AdvancedTopics/default_data_access.md
+++ b/doc/AdvancedTopics/default_data_access.md
@@ -7,6 +7,8 @@ When an FDA is created, the API can also create a built-in DA named `defaultData
 This DA is intended to provide an immediate, generic query surface for the whole FDA without requiring the client to
 manually define a first DA.
 
+Note that once created this DA is like anything other (i.e. any other created by the user using the proper API operation). Thus, it can be deleted, etc. using API operations related with DA management.
+
 ## Creation rules
 
 Default DA creation is enabled by default and can be controlled in two ways:

--- a/doc/AdvancedTopics/default_data_access.md
+++ b/doc/AdvancedTopics/default_data_access.md
@@ -48,6 +48,13 @@ LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT)
 OFFSET CAST(COALESCE($offset, 0) AS BIGINT)
 ```
 
+About `9223372036854775807` in `LIMIT`:
+
+-   This value is the maximum signed 64-bit integer (`BIGINT`), i.e. `2^63 - 1`.
+-   It is used as an "effectively unbounded" limit when `limit` is not provided.
+-   The generated query uses `COALESCE($limit, ...)` because SQL does not support expressing `LIMIT` with an
+    `($limit IS NULL OR ...)` pattern.
+
 Each FDA column gets one optional equality filter parameter with:
 
 -   `required: false` implicitly

--- a/doc/AdvancedTopics/default_data_access.md
+++ b/doc/AdvancedTopics/default_data_access.md
@@ -68,6 +68,16 @@ Current generated predicate shape:
 ($finish IS NULL OR CAST(timeColumn AS TIMESTAMP) <= CAST($finish AS TIMESTAMP))
 ```
 
+Important note about temporal columns:
+
+-   If an FDA includes a temporal column that is not declared as timeColumn, that column is treated as a regular
+    optional equality filter.
+-   In that case, exact equality comparisons may be unreliable because of timestamp precision and representation
+    differences.
+-   For reliable temporal filtering, declare the FDA timeColumn and use start and finish parameters.
+-   If a column is declared as `timeColumn`, the equality filter shape is:
+    `($${paramName} IS NULL OR DATE_TRUNC('millisecond', CAST(${quotedColumnName} AS TIMESTAMP)) = DATE_TRUNC('millisecond', CAST($${paramName} AS TIMESTAMP)))`.
+
 ## Pagination support
 
 Default DA also includes two optional pagination parameters:

--- a/doc/AdvancedTopics/default_data_access.md
+++ b/doc/AdvancedTopics/default_data_access.md
@@ -7,14 +7,17 @@ When an FDA is created, the API can also create a built-in DA named `defaultData
 This DA is intended to provide an immediate, generic query surface for the whole FDA without requiring the client to
 manually define a first DA.
 
-Note that once created this DA is like anything other (i.e. any other created by the user using the proper API operation). Thus, it can be deleted, etc. using API operations related with DA management.
+Note that once created this DA is like anything other (i.e. any other created by the user using the proper API
+operation). Thus, it can be deleted, etc. using API operations related with DA management.
 
 ## Creation rules
 
 Default DA creation is enabled by default and can be controlled in two ways:
 
--   `FDA_CREATE_DEFAULT_DATA_ACCESS` environment variable defines the instance default behavior.
--   `POST /{visibility}/fdas?defaultDataAccess=false` disables it for a specific FDA creation request.
+-   `FDA_CREATE_DEFAULT_DATA_ACCESS` environment variable defines the instance default behavior. Its default value is
+    `true`.
+-   `POST /{visibility}/fdas?defaultDataAccess=false` disables it for a specific FDA creation request, overriding the
+    instance default for that request only.
 
 If enabled, the DA is created automatically after the one-row bootstrap parquet is generated and before the async fetch
 job is scheduled.
@@ -100,4 +103,5 @@ particularly with predicates shaped as:
 ($p IS NULL OR col = $p)
 ```
 
-This limitation is currently accepted and pending design discussion.
+This limitation is currently accepted and pending design discussion in
+[#153](https://github.com/telefonicaid/fiware-data-access/issues/153).

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,6 +121,7 @@ services:
       - FDA_MONGO_URI=mongodb://mongo:27017/fiware-data-access
       - FDA_ROLE_APISERVER=true
       - FDA_ROLE_FETCHER=true
+      - FDA_CREATE_DEFAULT_DATA_ACCESS=true
     command: ['npm', 'start']
     logging:
       driver: "json-file"

--- a/src/index.js
+++ b/src/index.js
@@ -230,7 +230,7 @@ app.post('/:visibility/fdas', async (req, res) => {
       : parseBooleanQueryParam(
           req.query.defaultDataAccess,
           'defaultDataAccess',
-          (defaultValue = true),
+          true,
         );
 
   if (!id || !query || !service || !servicePath || !visibility) {

--- a/src/index.js
+++ b/src/index.js
@@ -223,6 +223,15 @@ app.post('/:visibility/fdas', async (req, res) => {
   const service = req.get('Fiware-Service');
   const servicePath = req.get('Fiware-ServicePath');
   const { visibility } = req.params;
+  const defaultDataAccessByConfig = config.defaultDataAccess?.enabled ?? true;
+  const defaultDataAccessEnabled =
+    req.query.defaultDataAccess === undefined
+      ? defaultDataAccessByConfig
+      : parseBooleanQueryParam(
+          req.query.defaultDataAccess,
+          'defaultDataAccess',
+          (defaultValue = true),
+        );
 
   if (!id || !query || !service || !servicePath || !visibility) {
     return res.status(400).json({
@@ -244,6 +253,7 @@ app.post('/:visibility/fdas', async (req, res) => {
     finalRefreshPolicy,
     timeColumn,
     finalObjStgConf,
+    defaultDataAccessEnabled,
   );
 
   return res.status(202).json({

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -1369,11 +1369,19 @@ async function buildDefaultDataAccessDefinition(
     const baseName = sanitizeDefaultDAParamBaseName(columnName);
     const paramName = getUniqueDefaultDAParamName(baseName, usedParamNames);
     const quotedColumnName = quoteDuckDBIdentifier(columnName);
+    const isResolvedTimeColumn =
+      resolvedTimeColumn && columnName === resolvedTimeColumn;
 
     params.push({ name: paramName, default: null });
-    filters.push(
-      `($${paramName} IS NULL OR ${quotedColumnName} = $${paramName})`,
-    );
+    if (isResolvedTimeColumn) {
+      filters.push(
+        `($${paramName} IS NULL OR DATE_TRUNC('millisecond', CAST(${quotedColumnName} AS TIMESTAMP)) = DATE_TRUNC('millisecond', CAST($${paramName} AS TIMESTAMP)))`,
+      );
+    } else {
+      filters.push(
+        `($${paramName} IS NULL OR ${quotedColumnName} = $${paramName})`,
+      );
+    }
   }
 
   if (resolvedTimeColumn) {

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -616,6 +616,7 @@ export async function fetchFDA(
         service,
         fdaId,
         normalizedServicePath,
+        timeColumn,
       );
 
       await createDA(
@@ -1326,18 +1327,41 @@ function buildOneRowQuery(query) {
   return `SELECT * FROM (${normalizedQuery}) AS fda_one_row LIMIT 1`;
 }
 
-async function buildDefaultDataAccessDefinition(service, fdaId, servicePath) {
+async function buildDefaultDataAccessDefinition(
+  service,
+  fdaId,
+  servicePath,
+  timeColumn,
+) {
   const columns = await getFDAColumnNamesFromParquet(
     service,
     fdaId,
     servicePath,
   );
 
-  if (columns.length === 0) {
-    return { query: 'SELECT *', params: [] };
+  const resolvedTimeColumn = resolveDefaultDATimeColumnName(
+    timeColumn,
+    columns,
+  );
+  const reservedParamNames = ['limit', 'offset'];
+  if (resolvedTimeColumn) {
+    reservedParamNames.push('start', 'finish');
   }
 
-  const usedParamNames = new Set();
+  if (columns.length === 0) {
+    const params = reservedParamNames.map((name) => ({
+      name,
+      default: null,
+    }));
+
+    return {
+      query:
+        'SELECT * LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)',
+      params,
+    };
+  }
+
+  const usedParamNames = new Set(reservedParamNames);
   const params = [];
   const filters = [];
 
@@ -1352,10 +1376,47 @@ async function buildDefaultDataAccessDefinition(service, fdaId, servicePath) {
     );
   }
 
+  if (resolvedTimeColumn) {
+    const quotedTimeColumn = quoteDuckDBIdentifier(resolvedTimeColumn);
+    params.push({ name: 'start', default: null });
+    params.push({ name: 'finish', default: null });
+    filters.push(
+      `($start IS NULL OR CAST(${quotedTimeColumn} AS TIMESTAMP) >= CAST($start AS TIMESTAMP))`,
+    );
+    filters.push(
+      `($finish IS NULL OR CAST(${quotedTimeColumn} AS TIMESTAMP) <= CAST($finish AS TIMESTAMP))`,
+    );
+  }
+
+  params.push({ name: 'limit', default: null });
+  params.push({ name: 'offset', default: null });
+
+  const whereClause =
+    filters.length > 0 ? ` WHERE ${filters.join(' AND ')}` : '';
+
   return {
-    query: `SELECT * WHERE ${filters.join(' AND ')}`,
+    query: `SELECT *${whereClause} LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)`,
     params,
   };
+}
+
+function resolveDefaultDATimeColumnName(timeColumn, columns) {
+  if (typeof timeColumn !== 'string' || timeColumn.length === 0) {
+    return null;
+  }
+
+  const exactMatch = columns.find((column) => column === timeColumn);
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const lowerTimeColumn = timeColumn.toLowerCase();
+  return (
+    columns.find(
+      (column) =>
+        typeof column === 'string' && column.toLowerCase() === lowerTimeColumn,
+    ) || null
+  );
 }
 
 async function getFDAColumnNamesFromParquet(service, fdaId, servicePath) {

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -609,6 +609,29 @@ export async function fetchFDA(
     throw err;
   }
 
+  if (config.defaultDataAccess.enabled) {
+    try {
+      await createDA(
+        service,
+        fdaId,
+        'defaultDataAccess',
+        'Default Data Access providing access to the whole table',
+        'SELECT *',
+        undefined,
+        normalizedVisibility,
+        normalizedServicePath,
+      );
+    } catch (err) {
+      // If default DA creation fails, rollback the entire FDA
+      await rollbackFDAProvisioning(service, fdaId, normalizedServicePath);
+      throw new FDAError(
+        500,
+        'DefaultDataAccessCreationError',
+        `Failed to create default Data Access for FDA ${fdaId}: ${err.message}`,
+      );
+    }
+  }
+
   const agenda = getAgenda();
 
   // Execute first fetch immediately (when a fetcher is free)

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -1328,11 +1328,16 @@ async function rollbackFDAProvisioning(service, fdaId, servicePath) {
   const storagePath = getFDAStoragePath(fdaId, servicePath);
   const bucketName = getBucketNameFromService(service);
 
-  await Promise.allSettled([
+  const rollbackResults = await Promise.allSettled([
     dropFile(s3Client, bucketName, `${storagePath}.csv`),
     dropFile(s3Client, bucketName, `${storagePath}.parquet`),
     removeFDA(service, fdaId, servicePath),
   ]);
+
+  const mongoRollbackResult = rollbackResults[2];
+  if (mongoRollbackResult.status === 'rejected') {
+    throw mongoRollbackResult.reason;
+  }
 }
 
 const getPath = (bucket, path, extension) => {

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -612,13 +612,19 @@ export async function fetchFDA(
 
   if (defaultDataAccessEnabled) {
     try {
+      const defaultDA = await buildDefaultDataAccessDefinition(
+        service,
+        fdaId,
+        normalizedServicePath,
+      );
+
       await createDA(
         service,
         fdaId,
         'defaultDataAccess',
-        'Default Data Access providing access to the whole table',
-        'SELECT *',
-        undefined,
+        'Default Data Access providing access to whole FDA data. It has parameters for all columns in the FDA.',
+        defaultDA.query,
+        defaultDA.params,
         normalizedVisibility,
         normalizedServicePath,
       );
@@ -1318,6 +1324,99 @@ async function createOneRowParquetSync(service, fdaId, query, servicePath) {
 function buildOneRowQuery(query) {
   const normalizedQuery = query.trim().replace(/;+\s*$/, '');
   return `SELECT * FROM (${normalizedQuery}) AS fda_one_row LIMIT 1`;
+}
+
+async function buildDefaultDataAccessDefinition(service, fdaId, servicePath) {
+  const columns = await getFDAColumnNamesFromParquet(
+    service,
+    fdaId,
+    servicePath,
+  );
+
+  if (columns.length === 0) {
+    return { query: 'SELECT *', params: [] };
+  }
+
+  const usedParamNames = new Set();
+  const params = [];
+  const filters = [];
+
+  for (const columnName of columns) {
+    const baseName = sanitizeDefaultDAParamBaseName(columnName);
+    const paramName = getUniqueDefaultDAParamName(baseName, usedParamNames);
+    const quotedColumnName = quoteDuckDBIdentifier(columnName);
+
+    params.push({ name: paramName, default: null });
+    filters.push(
+      `($${paramName} IS NULL OR ${quotedColumnName} = $${paramName})`,
+    );
+  }
+
+  return {
+    query: `SELECT * WHERE ${filters.join(' AND ')}`,
+    params,
+  };
+}
+
+async function getFDAColumnNamesFromParquet(service, fdaId, servicePath) {
+  const conn = await getDBConnection();
+  try {
+    const storagePath = getFDAStoragePath(fdaId, servicePath);
+    const bucketName = getBucketNameFromService(service);
+    const parquetPath = `s3://${bucketName}/${storagePath}.parquet`;
+    const safeParquetPath = parquetPath.replace(/'/g, "''");
+
+    const describeResult = await conn.run(
+      `DESCRIBE SELECT * FROM read_parquet('${safeParquetPath}')`,
+    );
+    const describeRows = await Promise.resolve(
+      describeResult.getRowObjectsJson(),
+    );
+
+    return describeRows
+      .map(
+        (row) =>
+          row?.column_name ?? row?.columnName ?? row?.name ?? row?.column,
+      )
+      .filter((name) => typeof name === 'string' && name.length > 0);
+  } finally {
+    await releaseDBConnection(conn);
+  }
+}
+
+function quoteDuckDBIdentifier(identifier) {
+  return `"${String(identifier).replace(/"/g, '""')}"`;
+}
+
+function sanitizeDefaultDAParamBaseName(columnName) {
+  const normalized = String(columnName)
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+  if (!normalized) {
+    return 'col';
+  }
+
+  if (/^[0-9]/.test(normalized)) {
+    return `col_${normalized}`;
+  }
+
+  return normalized;
+}
+
+function getUniqueDefaultDAParamName(baseName, usedParamNames) {
+  let candidate = baseName;
+  let suffix = 2;
+
+  while (usedParamNames.has(candidate)) {
+    candidate = `${baseName}_${suffix}`;
+    suffix += 1;
+  }
+
+  usedParamNames.add(candidate);
+  return candidate;
 }
 
 async function rollbackFDAProvisioning(service, fdaId, servicePath) {

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -576,6 +576,7 @@ export async function fetchFDA(
   refreshPolicy,
   timeColumn,
   objStgConf,
+  defaultDataAccessEnabled,
 ) {
   validateScheduledOptions(refreshPolicy, objStgConf);
   const timeQuery =
@@ -609,7 +610,7 @@ export async function fetchFDA(
     throw err;
   }
 
-  if (config.defaultDataAccess.enabled) {
+  if (defaultDataAccessEnabled) {
     try {
       await createDA(
         service,

--- a/src/lib/fdaConfig.js
+++ b/src/lib/fdaConfig.js
@@ -131,6 +131,10 @@ const envVarsSchema = {
       type: 'number',
       default: 5,
     },
+    FDA_CREATE_DEFAULT_DATA_ACCESS: {
+      type: 'boolean',
+      default: true,
+    },
   },
 };
 
@@ -181,5 +185,8 @@ export const config = {
   },
   freshQueries: {
     maxConcurrent: envVars.FDA_MAX_CONCURRENT_FRESH_QUERIES,
+  },
+  defaultDataAccess: {
+    enabled: envVars.FDA_CREATE_DEFAULT_DATA_ACCESS,
   },
 };

--- a/src/lib/utils/db.js
+++ b/src/lib/utils/db.js
@@ -207,15 +207,7 @@ export function checkParams(params) {
   }
 
   return params.map((param) => {
-    if (!param.type) {
-      throw new FDAError(
-        400,
-        'InvalidParam',
-        `Type is a mandatory key in every param.`,
-      );
-    }
-
-    if (!Object.keys(TYPE_COERCERS).includes(param.type)) {
+    if (param.type && !Object.keys(TYPE_COERCERS).includes(param.type)) {
       throw new FDAError(400, 'InvalidParam', `Invalid value in type key.`);
     }
 
@@ -260,17 +252,23 @@ export function checkParams(params) {
     const normalizedParam = { ...param };
 
     if (Object.prototype.hasOwnProperty.call(param, 'default')) {
-      const coercedDefault = isTypeOf(param.default, param.type);
+      let normalizedDefault = param.default;
 
-      if (coercedDefault === undefined) {
-        throw new FDAError(
-          400,
-          'InvalidParam',
-          `Default value for param "${param.name}" not of valid type (${param.type}).`,
-        );
+      if (param.type) {
+        const coercedDefault = isTypeOf(param.default, param.type);
+
+        if (coercedDefault === undefined) {
+          throw new FDAError(
+            400,
+            'InvalidParam',
+            `Default value for param "${param.name}" not of valid type (${param.type}).`,
+          );
+        }
+
+        normalizedDefault = coercedDefault;
       }
 
-      if (param.range && !isInRange(coercedDefault, param.range)) {
+      if (param.range && !isInRange(normalizedDefault, param.range)) {
         throw new FDAError(
           400,
           'InvalidParam',
@@ -278,7 +276,7 @@ export function checkParams(params) {
         );
       }
 
-      if (param.enum && !isInEnum(coercedDefault, param.enum)) {
+      if (param.enum && !isInEnum(normalizedDefault, param.enum)) {
         throw new FDAError(
           400,
           'InvalidParam',
@@ -286,7 +284,8 @@ export function checkParams(params) {
         );
       }
 
-      normalizedParam.default = normalizeParamDefaultForStorage(coercedDefault);
+      normalizedParam.default =
+        normalizeParamDefaultForStorage(normalizedDefault);
     }
 
     return normalizedParam;

--- a/src/lib/utils/mongo.js
+++ b/src/lib/utils/mongo.js
@@ -256,10 +256,6 @@ export async function removeFDA(service, fdaId, servicePath) {
       );
     }
   } catch (e) {
-    if (e instanceof FDAError) {
-      throw e;
-    }
-
     throw new FDAError(
       500,
       'MongoDBServerError',

--- a/src/lib/utils/mongo.js
+++ b/src/lib/utils/mongo.js
@@ -256,6 +256,10 @@ export async function removeFDA(service, fdaId, servicePath) {
       );
     }
   } catch (e) {
+    if (e instanceof FDAError) {
+      throw e;
+    }
+
     throw new FDAError(
       500,
       'MongoDBServerError',

--- a/src/lib/utils/utils.js
+++ b/src/lib/utils/utils.js
@@ -113,9 +113,9 @@ export function validateForbiddenFieldsQuery(query, forbiddenFields) {
   }
 }
 
-export function parseBooleanQueryParam(value, name) {
+export function parseBooleanQueryParam(value, name, defaultValue = false) {
   if (value === undefined) {
-    return false;
+    return defaultValue;
   }
 
   if (value === true || value === false) {

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -1095,6 +1095,128 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(res.json.some((x) => x.id === fdaId)).toBe(true);
     });
 
+    test('defaultDataAccess includes start/finish and limit/offset when FDA has timeColumn', async () => {
+      const timedFdaId = 'fda_default_da_timed';
+
+      try {
+        const createFda = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+          body: {
+            id: timedFdaId,
+            query:
+              'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+            description: 'default DA timed test',
+            timeColumn: 'timeinstant',
+          },
+        });
+
+        expect(createFda.status).toBe(202);
+        const completedFDA = await waitUntilFDACompleted({
+          baseUrl,
+          service,
+          fdaId: timedFdaId,
+        });
+
+        const defaultDa = completedFDA?.das?.defaultDataAccess;
+        expect(defaultDa).toBeDefined();
+        expect(defaultDa.query).toContain(
+          '($start IS NULL OR CAST("timeinstant" AS TIMESTAMP) >= CAST($start AS TIMESTAMP))',
+        );
+        expect(defaultDa.query).toContain(
+          '($finish IS NULL OR CAST("timeinstant" AS TIMESTAMP) <= CAST($finish AS TIMESTAMP))',
+        );
+        expect(defaultDa.query).toContain(
+          'LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)',
+        );
+        expect(defaultDa.params.some((p) => p.name === 'start')).toBe(true);
+        expect(defaultDa.params.some((p) => p.name === 'finish')).toBe(true);
+        expect(defaultDa.params.some((p) => p.name === 'limit')).toBe(true);
+        expect(defaultDa.params.some((p) => p.name === 'offset')).toBe(true);
+      } finally {
+        await httpReq({
+          method: 'DELETE',
+          url: `${baseUrl}/${visibility}/fdas/${timedFdaId}`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+      }
+    });
+
+    test('defaultDataAccess supports start/finish and limit/offset in cached mode', async () => {
+      const timedFdaId = 'fda_default_da_timed_data';
+
+      try {
+        const createFda = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+          body: {
+            id: timedFdaId,
+            query:
+              'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+            description: 'default DA timed data test',
+            timeColumn: 'timeinstant',
+          },
+        });
+
+        expect(createFda.status).toBe(202);
+        await waitUntilFDACompleted({
+          baseUrl,
+          service,
+          fdaId: timedFdaId,
+        });
+
+        const rangeAndPagingRes = await httpReq({
+          method: 'GET',
+          url: buildDaDataUrl(
+            baseUrl,
+            servicePath,
+            timedFdaId,
+            'defaultDataAccess',
+            {
+              start: '2020-01-01T00:00:00.000Z',
+              finish: '2020-12-31T23:59:59.000Z',
+              limit: 1,
+              offset: 1,
+            },
+          ),
+          headers: { 'Fiware-Service': service },
+        });
+
+        if (rangeAndPagingRes.status >= 400) {
+          console.error(
+            'GET defaultDataAccess with start/finish/limit/offset failed:',
+            rangeAndPagingRes.status,
+            rangeAndPagingRes.json ?? rangeAndPagingRes.text,
+          );
+        }
+
+        expect(rangeAndPagingRes.status).toBe(200);
+        expect(Array.isArray(rangeAndPagingRes.json)).toBe(true);
+        expect(rangeAndPagingRes.json).toHaveLength(1);
+        expect(rangeAndPagingRes.json[0].id).toBe('2');
+      } finally {
+        await httpReq({
+          method: 'DELETE',
+          url: `${baseUrl}/${visibility}/fdas/${timedFdaId}`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+      }
+    });
+
     test('POST /fdas/:fdaId/das + GET /{visibility}/fdas/{fdaId}/das/{daId}/data executes DuckDB against Parquet', async () => {
       // DuckDB reads parquet generated in  s3://<bucket>/<fdaID>.parquet
       const daQuery = `

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -1095,6 +1095,110 @@ export function runFDAIntegrationSuite({ mode, label }) {
       expect(res.json.some((x) => x.id === fdaId)).toBe(true);
     });
 
+    test('POST /fdas?defaultDataAccess=false creates FDA without default DA', async () => {
+      const disabledFdaId = 'fda_default_da_disabled';
+
+      try {
+        const createFda = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas?defaultDataAccess=false`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+          body: {
+            id: disabledFdaId,
+            query:
+              'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+            description: 'default DA disabled test',
+          },
+        });
+
+        expect(createFda.status).toBe(202);
+        const completedFDA = await waitUntilFDACompleted({
+          baseUrl,
+          service,
+          fdaId: disabledFdaId,
+        });
+
+        expect(completedFDA?.das || {}).toEqual({});
+      } finally {
+        await httpReq({
+          method: 'DELETE',
+          url: `${baseUrl}/${visibility}/fdas/${disabledFdaId}`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+      }
+    });
+
+    test('defaultDataAccess without timeColumn includes limit/offset but not start/finish', async () => {
+      const untimedFdaId = 'fda_default_da_untimed';
+
+      try {
+        const createFda = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+          body: {
+            id: untimedFdaId,
+            query:
+              'SELECT id, name, age, authorized FROM public.users ORDER BY id',
+            description: 'default DA untimed test',
+          },
+        });
+
+        expect(createFda.status).toBe(202);
+        const completedFDA = await waitUntilFDACompleted({
+          baseUrl,
+          service,
+          fdaId: untimedFdaId,
+        });
+
+        const defaultDa = completedFDA?.das?.defaultDataAccess;
+        expect(defaultDa).toBeDefined();
+        expect(defaultDa.query).toContain(
+          'LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)',
+        );
+        expect(defaultDa.query).not.toContain('$start');
+        expect(defaultDa.query).not.toContain('$finish');
+        expect(defaultDa.params.some((p) => p.name === 'limit')).toBe(true);
+        expect(defaultDa.params.some((p) => p.name === 'offset')).toBe(true);
+        expect(defaultDa.params.some((p) => p.name === 'start')).toBe(false);
+        expect(defaultDa.params.some((p) => p.name === 'finish')).toBe(false);
+
+        const pagingRes = await httpReq({
+          method: 'GET',
+          url: buildDaDataUrl(
+            baseUrl,
+            servicePath,
+            untimedFdaId,
+            'defaultDataAccess',
+            { limit: 1, offset: 2 },
+          ),
+          headers: { 'Fiware-Service': service },
+        });
+
+        expect(pagingRes.status).toBe(200);
+        expect(pagingRes.json).toHaveLength(1);
+        expect(pagingRes.json[0].id).toBe('3');
+      } finally {
+        await httpReq({
+          method: 'DELETE',
+          url: `${baseUrl}/${visibility}/fdas/${untimedFdaId}`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+      }
+    });
+
     test('defaultDataAccess includes start/finish and limit/offset when FDA has timeColumn', async () => {
       const timedFdaId = 'fda_default_da_timed';
 

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -1321,6 +1321,70 @@ export function runFDAIntegrationSuite({ mode, label }) {
       }
     });
 
+    test('defaultDataAccess matches exact equality on declared timeColumn in cached mode', async () => {
+      const timedFdaId = 'fda_default_da_timed_equality';
+
+      try {
+        const createFda = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+          body: {
+            id: timedFdaId,
+            query:
+              'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+            description: 'default DA timed equality test',
+            timeColumn: 'timeinstant',
+          },
+        });
+
+        expect(createFda.status).toBe(202);
+        await waitUntilFDACompleted({
+          baseUrl,
+          service,
+          fdaId: timedFdaId,
+        });
+
+        const equalityRes = await httpReq({
+          method: 'GET',
+          url: buildDaDataUrl(
+            baseUrl,
+            servicePath,
+            timedFdaId,
+            'defaultDataAccess',
+            {
+              timeinstant: '2020-08-17T18:25:28.332Z',
+            },
+          ),
+          headers: { 'Fiware-Service': service },
+        });
+
+        if (equalityRes.status >= 400) {
+          console.error(
+            'GET defaultDataAccess with exact timeColumn equality failed:',
+            equalityRes.status,
+            equalityRes.json ?? equalityRes.text,
+          );
+        }
+
+        expect(equalityRes.status).toBe(200);
+        expect(Array.isArray(equalityRes.json)).toBe(true);
+        expect(equalityRes.json.map((row) => row.id)).toEqual(['1', '2', '3']);
+      } finally {
+        await httpReq({
+          method: 'DELETE',
+          url: `${baseUrl}/${visibility}/fdas/${timedFdaId}`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+      }
+    });
+
     test('POST /fdas/:fdaId/das + GET /{visibility}/fdas/{fdaId}/das/{daId}/data executes DuckDB against Parquet', async () => {
       // DuckDB reads parquet generated in  s3://<bucket>/<fdaID>.parquet
       const daQuery = `

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -479,12 +479,10 @@ describe('db utils', () => {
     expect(checkParams(undefined)).toBeUndefined();
   });
 
-  test('checkParams throws FDAError when param missing type', async () => {
+  test('checkParams accepts param missing type', async () => {
     const { checkParams } = await loadDbModule();
 
-    expect(() => checkParams([{ name: 'id' }])).toThrow(
-      'Type is a mandatory key in every param.',
-    );
+    expect(checkParams([{ name: 'id' }])).toEqual([{ name: 'id' }]);
   });
 
   test('checkParams throws FDAError for invalid type value', async () => {

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -880,7 +880,7 @@ describe('fetchFDA', () => {
       '/servicepath',
       'defaultDataAccess',
       'Default Data Access providing access to whole FDA data. It has parameters for all columns in the FDA.',
-      'SELECT * WHERE ($entity_id IS NULL OR "entity-id" = $entity_id) AND ($limit_2 IS NULL OR "limit" = $limit_2) AND ($timeinstant IS NULL OR "timeinstant" = $timeinstant) AND ($start IS NULL OR CAST("timeinstant" AS TIMESTAMP) >= CAST($start AS TIMESTAMP)) AND ($finish IS NULL OR CAST("timeinstant" AS TIMESTAMP) <= CAST($finish AS TIMESTAMP)) LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)',
+      'SELECT * WHERE ($entity_id IS NULL OR "entity-id" = $entity_id) AND ($limit_2 IS NULL OR "limit" = $limit_2) AND ($timeinstant IS NULL OR DATE_TRUNC(\'millisecond\', CAST("timeinstant" AS TIMESTAMP)) = DATE_TRUNC(\'millisecond\', CAST($timeinstant AS TIMESTAMP))) AND ($start IS NULL OR CAST("timeinstant" AS TIMESTAMP) >= CAST($start AS TIMESTAMP)) AND ($finish IS NULL OR CAST("timeinstant" AS TIMESTAMP) <= CAST($finish AS TIMESTAMP)) LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)',
       [
         { name: 'entity_id', default: null },
         { name: 'limit_2', default: null },

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -833,6 +833,193 @@ describe('fetchFDA', () => {
     expect(agenda.every).not.toHaveBeenCalled();
   });
 
+  test('creates default DA with optional filters, time range and pagination params', async () => {
+    const describeRun = jest.fn().mockResolvedValue({
+      getRowObjectsJson: () => [
+        { column_name: 'entity-id' },
+        { column_name: 'limit' },
+        { column_name: 'timeinstant' },
+      ],
+    });
+
+    dbMocks.getDBConnection
+      .mockReset()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ run: describeRun })
+      .mockResolvedValueOnce({});
+    dbMocks.releaseDBConnection.mockReset().mockResolvedValue(undefined);
+    dbMocks.validateDAQuery.mockReset().mockResolvedValue(undefined);
+    dbMocks.checkParams.mockImplementation((params) => params);
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      visibility: 'public',
+      servicePath: '/servicepath',
+    });
+    mongoMocks.retrieveDA.mockResolvedValue(null);
+
+    await fetchFDA(
+      'fda1',
+      'SELECT id FROM users;',
+      'svc',
+      'public',
+      '/servicepath',
+      'test FDA',
+      {
+        type: 'none',
+      },
+      'timeinstant',
+      undefined,
+      true,
+    );
+
+    expect(describeRun).toHaveBeenCalledWith(
+      "DESCRIBE SELECT * FROM read_parquet('s3://svc/servicepath/fda1.parquet')",
+    );
+    expect(mongoMocks.storeDA).toHaveBeenCalledWith(
+      'svc',
+      'fda1',
+      '/servicepath',
+      'defaultDataAccess',
+      'Default Data Access providing access to whole FDA data. It has parameters for all columns in the FDA.',
+      'SELECT * WHERE ($entity_id IS NULL OR "entity-id" = $entity_id) AND ($limit_2 IS NULL OR "limit" = $limit_2) AND ($timeinstant IS NULL OR "timeinstant" = $timeinstant) AND ($start IS NULL OR CAST("timeinstant" AS TIMESTAMP) >= CAST($start AS TIMESTAMP)) AND ($finish IS NULL OR CAST("timeinstant" AS TIMESTAMP) <= CAST($finish AS TIMESTAMP)) LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)',
+      [
+        { name: 'entity_id', default: null },
+        { name: 'limit_2', default: null },
+        { name: 'timeinstant', default: null },
+        { name: 'start', default: null },
+        { name: 'finish', default: null },
+        { name: 'limit', default: null },
+        { name: 'offset', default: null },
+      ],
+    );
+  });
+
+  test('creates default DA without time filters when FDA has no timeColumn', async () => {
+    const describeRun = jest.fn().mockResolvedValue({
+      getRowObjectsJson: () => [{ column_name: 'name' }],
+    });
+
+    dbMocks.getDBConnection
+      .mockReset()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ run: describeRun })
+      .mockResolvedValueOnce({});
+    dbMocks.releaseDBConnection.mockReset().mockResolvedValue(undefined);
+    dbMocks.validateDAQuery.mockReset().mockResolvedValue(undefined);
+    dbMocks.checkParams.mockImplementation((params) => params);
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      visibility: 'public',
+      servicePath: '/servicepath',
+    });
+    mongoMocks.retrieveDA.mockResolvedValue(null);
+
+    await fetchFDA(
+      'fda1',
+      'SELECT id FROM users;',
+      'svc',
+      'public',
+      '/servicepath',
+      'test FDA',
+      {
+        type: 'none',
+      },
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(mongoMocks.storeDA).toHaveBeenCalledWith(
+      'svc',
+      'fda1',
+      '/servicepath',
+      'defaultDataAccess',
+      'Default Data Access providing access to whole FDA data. It has parameters for all columns in the FDA.',
+      'SELECT * WHERE ($name IS NULL OR "name" = $name) LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)',
+      [
+        { name: 'name', default: null },
+        { name: 'limit', default: null },
+        { name: 'offset', default: null },
+      ],
+    );
+  });
+
+  test('does not create default DA when disabled', async () => {
+    await fetchFDA(
+      'fda1',
+      'SELECT id FROM users;',
+      'svc',
+      'public',
+      '/servicepath',
+      'test FDA',
+      {
+        type: 'none',
+      },
+      'timeinstant',
+      undefined,
+      false,
+    );
+
+    expect(mongoMocks.storeDA).not.toHaveBeenCalled();
+  });
+
+  test('rolls back FDA provisioning when default DA creation fails', async () => {
+    const describeRun = jest.fn().mockResolvedValue({
+      getRowObjectsJson: () => [{ column_name: 'name' }],
+    });
+
+    dbMocks.getDBConnection
+      .mockReset()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ run: describeRun })
+      .mockResolvedValueOnce({});
+    dbMocks.releaseDBConnection.mockReset().mockResolvedValue(undefined);
+    dbMocks.checkParams.mockImplementation((params) => params);
+    dbMocks.validateDAQuery.mockRejectedValueOnce(
+      new Error('invalid default DA'),
+    );
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      visibility: 'public',
+      servicePath: '/servicepath',
+    });
+    mongoMocks.retrieveDA.mockResolvedValue(null);
+
+    await expect(
+      fetchFDA(
+        'fda1',
+        'SELECT id FROM users;',
+        'svc',
+        'public',
+        '/servicepath',
+        'test FDA',
+        {
+          type: 'none',
+        },
+        'timeinstant',
+        undefined,
+        true,
+      ),
+    ).rejects.toMatchObject({
+      status: 500,
+      type: 'DefaultDataAccessCreationError',
+    });
+
+    expect(mongoMocks.removeFDA).toHaveBeenCalledWith(
+      'svc',
+      'fda1',
+      '/servicepath',
+    );
+    expect(awsMocks.dropFile).toHaveBeenCalledWith(
+      {},
+      'svc',
+      'servicepath/fda1.csv',
+    );
+    expect(awsMocks.dropFile).toHaveBeenCalledWith(
+      {},
+      'svc',
+      'servicepath/fda1.parquet',
+    );
+    expect(agenda.now).not.toHaveBeenCalled();
+  });
+
   test('schedules periodic refresh for interval policy', async () => {
     await fetchFDA(
       'fda1',

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -942,6 +942,219 @@ describe('fetchFDA', () => {
     );
   });
 
+  test('creates default DA with time filters when timeColumn matches columns case-insensitively', async () => {
+    const describeRun = jest.fn().mockResolvedValue({
+      getRowObjectsJson: () => [
+        { column_name: 'TimeInstant' },
+        { column_name: 'name' },
+      ],
+    });
+
+    dbMocks.getDBConnection
+      .mockReset()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ run: describeRun })
+      .mockResolvedValueOnce({});
+    dbMocks.releaseDBConnection.mockReset().mockResolvedValue(undefined);
+    dbMocks.validateDAQuery.mockReset().mockResolvedValue(undefined);
+    dbMocks.checkParams.mockImplementation((params) => params);
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      visibility: 'public',
+      servicePath: '/servicepath',
+    });
+    mongoMocks.retrieveDA.mockResolvedValue(null);
+
+    await fetchFDA(
+      'fda1',
+      'SELECT id FROM users;',
+      'svc',
+      'public',
+      '/servicepath',
+      'test FDA',
+      {
+        type: 'none',
+      },
+      'timeinstant',
+      undefined,
+      true,
+    );
+
+    expect(mongoMocks.storeDA).toHaveBeenCalledWith(
+      'svc',
+      'fda1',
+      '/servicepath',
+      'defaultDataAccess',
+      'Default Data Access providing access to whole FDA data. It has parameters for all columns in the FDA.',
+      'SELECT * WHERE ($timeinstant IS NULL OR DATE_TRUNC(\'millisecond\', CAST("TimeInstant" AS TIMESTAMP)) = DATE_TRUNC(\'millisecond\', CAST($timeinstant AS TIMESTAMP))) AND ($name IS NULL OR "name" = $name) AND ($start IS NULL OR CAST("TimeInstant" AS TIMESTAMP) >= CAST($start AS TIMESTAMP)) AND ($finish IS NULL OR CAST("TimeInstant" AS TIMESTAMP) <= CAST($finish AS TIMESTAMP)) LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)',
+      [
+        { name: 'timeinstant', default: null },
+        { name: 'name', default: null },
+        { name: 'start', default: null },
+        { name: 'finish', default: null },
+        { name: 'limit', default: null },
+        { name: 'offset', default: null },
+      ],
+    );
+  });
+
+  test('creates default DA without time range when configured timeColumn is not present in parquet columns', async () => {
+    const describeRun = jest.fn().mockResolvedValue({
+      getRowObjectsJson: () => [
+        { column_name: 'timeinstant' },
+        { column_name: 'name' },
+      ],
+    });
+
+    dbMocks.getDBConnection
+      .mockReset()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ run: describeRun })
+      .mockResolvedValueOnce({});
+    dbMocks.releaseDBConnection.mockReset().mockResolvedValue(undefined);
+    dbMocks.validateDAQuery.mockReset().mockResolvedValue(undefined);
+    dbMocks.checkParams.mockImplementation((params) => params);
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      visibility: 'public',
+      servicePath: '/servicepath',
+    });
+    mongoMocks.retrieveDA.mockResolvedValue(null);
+
+    await fetchFDA(
+      'fda1',
+      'SELECT id FROM users;',
+      'svc',
+      'public',
+      '/servicepath',
+      'test FDA',
+      {
+        type: 'none',
+      },
+      'observed_at',
+      undefined,
+      true,
+    );
+
+    expect(mongoMocks.storeDA).toHaveBeenCalledWith(
+      'svc',
+      'fda1',
+      '/servicepath',
+      'defaultDataAccess',
+      'Default Data Access providing access to whole FDA data. It has parameters for all columns in the FDA.',
+      'SELECT * WHERE ($timeinstant IS NULL OR "timeinstant" = $timeinstant) AND ($name IS NULL OR "name" = $name) LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)',
+      [
+        { name: 'timeinstant', default: null },
+        { name: 'name', default: null },
+        { name: 'limit', default: null },
+        { name: 'offset', default: null },
+      ],
+    );
+  });
+
+  test('creates default DA with pagination only when parquet has no columns', async () => {
+    const describeRun = jest.fn().mockResolvedValue({
+      getRowObjectsJson: () => [],
+    });
+
+    dbMocks.getDBConnection
+      .mockReset()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ run: describeRun })
+      .mockResolvedValueOnce({});
+    dbMocks.releaseDBConnection.mockReset().mockResolvedValue(undefined);
+    dbMocks.validateDAQuery.mockReset().mockResolvedValue(undefined);
+    dbMocks.checkParams.mockImplementation((params) => params);
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      visibility: 'public',
+      servicePath: '/servicepath',
+    });
+    mongoMocks.retrieveDA.mockResolvedValue(null);
+
+    await fetchFDA(
+      'fda1',
+      'SELECT id FROM users;',
+      'svc',
+      'public',
+      '/servicepath',
+      'test FDA',
+      {
+        type: 'none',
+      },
+      'timeinstant',
+      undefined,
+      true,
+    );
+
+    expect(mongoMocks.storeDA).toHaveBeenCalledWith(
+      'svc',
+      'fda1',
+      '/servicepath',
+      'defaultDataAccess',
+      'Default Data Access providing access to whole FDA data. It has parameters for all columns in the FDA.',
+      'SELECT * LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)',
+      [
+        { name: 'limit', default: null },
+        { name: 'offset', default: null },
+      ],
+    );
+  });
+
+  test('sanitizes generated default DA param names and avoids reserved collisions', async () => {
+    const describeRun = jest.fn().mockResolvedValue({
+      getRowObjectsJson: () => [
+        { column_name: '123value' },
+        { column_name: '!!!' },
+        { column_name: 'offset' },
+        { column_name: 'my"col' },
+      ],
+    });
+
+    dbMocks.getDBConnection
+      .mockReset()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ run: describeRun })
+      .mockResolvedValueOnce({});
+    dbMocks.releaseDBConnection.mockReset().mockResolvedValue(undefined);
+    dbMocks.validateDAQuery.mockReset().mockResolvedValue(undefined);
+    dbMocks.checkParams.mockImplementation((params) => params);
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      visibility: 'public',
+      servicePath: '/servicepath',
+    });
+    mongoMocks.retrieveDA.mockResolvedValue(null);
+
+    await fetchFDA(
+      'fda1',
+      'SELECT id FROM users;',
+      'svc',
+      'public',
+      '/servicepath',
+      'test FDA',
+      {
+        type: 'none',
+      },
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(mongoMocks.storeDA).toHaveBeenCalledWith(
+      'svc',
+      'fda1',
+      '/servicepath',
+      'defaultDataAccess',
+      'Default Data Access providing access to whole FDA data. It has parameters for all columns in the FDA.',
+      'SELECT * WHERE ($col_123value IS NULL OR "123value" = $col_123value) AND ($col IS NULL OR "!!!" = $col) AND ($offset_2 IS NULL OR "offset" = $offset_2) AND ($my_col IS NULL OR "my""col" = $my_col) LIMIT CAST(COALESCE($limit, 9223372036854775807) AS BIGINT) OFFSET CAST(COALESCE($offset, 0) AS BIGINT)',
+      [
+        { name: 'col_123value', default: null },
+        { name: 'col', default: null },
+        { name: 'offset_2', default: null },
+        { name: 'my_col', default: null },
+        { name: 'limit', default: null },
+        { name: 'offset', default: null },
+      ],
+    );
+  });
+
   test('does not create default DA when disabled', async () => {
     await fetchFDA(
       'fda1',

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -570,6 +570,7 @@ describe('index routes - validation and middleware branches', () => {
       { type: 'none' },
       undefined,
       {},
+      true,
     );
     expect(fdaMocks.updateFDA).toHaveBeenCalledWith(
       'svc',


### PR DESCRIPTION
Related Issue #133

At this time, this PR covers:
- Added a configuration flag to control default defaultDataAccess creation behavior `FDA_CREATE_DEFAULT_DATA_ACCESS`.
- Added the API query parameter override correctly in `POST FDA`.
- Default DA is created as a regular DA (same lifecycle/management behavior).
- Atomic failure policy is in place (rollback on provisioning errors).

For optional filters, we are using this pattern with default null values:
- WHERE $age IS NULL OR age = $age
- Param definition includes required: false and default: null

This works well on cached queries (Parquet + DuckDB), but not on fresh queries (direct PostgreSQL).

### Evidence from tests
- DA creation with optional age param: 201 Created
- Cached query without fresh: 200 OK
- Cached query with age filter: 200 OK
- Fresh query with age filter: 500 Internal Server Error
  - Error: could not determine data type of parameter $1

### Decision points to align
1. Keep current simple SQL pattern and accept that fresh mode is limited.
2. Infer types and generate typed SQL conditions for fresh compatibility.
3. Keep DA definition simple and enrich/typed-handle parameters at runtime only in fresh path.

I would appreciate feedback on which direction we prefer before we continue with implementation and documentation updates.