### PR TITLE
Fix issue bug delete fda

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Add: Pentaho CDA backward compatibility now supports browser-style `GET /plugin/cda/api/doQuery` with query params, including `outputType` (`json`, `csv`, `xls`) (#108)
+- Fix: FDA deletion now ignores missing Minio objects so Sliding Window and fresh FDAs can be removed even when no files were uploaded (#169)

--- a/src/lib/utils/aws.js
+++ b/src/lib/utils/aws.js
@@ -87,6 +87,16 @@ export async function dropFile(s3Client, bucket, path) {
       }),
     );
   } catch (e) {
+    if (
+      e?.$metadata?.httpStatusCode === 404 ||
+      e?.name === 'NotFound' ||
+      e?.name === 'NoSuchKey' ||
+      e?.Code === 'NoSuchKey' ||
+      e?.code === 'NoSuchKey'
+    ) {
+      return;
+    }
+
     throw new FDAError(
       500,
       'S3ServerError',
@@ -97,6 +107,11 @@ export async function dropFile(s3Client, bucket, path) {
 
 export async function dropFiles(s3Client, bucket, objsToRemove) {
   logger.debug({ bucket, objsToRemove }, '[DEBUG]: dropFiles');
+
+  if (!objsToRemove?.length) {
+    return;
+  }
+
   try {
     await s3Client.send(
       new DeleteObjectsCommand({

--- a/test/unit/aws.test.js
+++ b/test/unit/aws.test.js
@@ -129,6 +129,21 @@ describe('aws utils', () => {
     });
   });
 
+  test('dropFile ignores missing object errors', async () => {
+    const { dropFile } = await loadAwsModule();
+
+    currentS3Client.send.mockRejectedValueOnce(
+      Object.assign(new Error('missing'), {
+        name: 'NoSuchKey',
+        $metadata: { httpStatusCode: 404 },
+      }),
+    );
+
+    await expect(
+      dropFile(currentS3Client, 'bucket-a', 'file-a'),
+    ).resolves.toBeUndefined();
+  });
+
   test('dropFiles wraps delete errors with FDAError', async () => {
     const { dropFiles } = await loadAwsModule();
 
@@ -142,6 +157,16 @@ describe('aws utils', () => {
       status: 500,
       type: 'S3ServerError',
     });
+  });
+
+  test('dropFiles is a no-op for an empty object list', async () => {
+    const { dropFiles } = await loadAwsModule();
+
+    await expect(
+      dropFiles(currentS3Client, 'bucket-a', []),
+    ).resolves.toBeUndefined();
+
+    expect(currentS3Client.send).not.toHaveBeenCalled();
   });
 
   test('moveObject wraps aws moving object errors with FDAError', async () => {

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -2152,6 +2152,30 @@ describe('deleteFDA', () => {
     ]);
   });
 
+  test('deleteFDA removes FDA even when Minio has no matching objects', async () => {
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      _id: 'mongo-id',
+      visibility: 'private',
+      servicePath: '/servicepath',
+    });
+    awsMocks.listObjects.mockResolvedValue([]);
+
+    await deleteFDA('svc', 'fdaA', 'private', '/servicepath');
+
+    expect(awsMocks.dropFiles).toHaveBeenCalledWith({}, 'svc', []);
+    expect(mongoMocks.removeFDA).toHaveBeenCalledWith(
+      'svc',
+      'fdaA',
+      '/servicepath',
+    );
+    expect(agenda.cancel).toHaveBeenCalledWith({
+      name: 'refresh-fda',
+      'data.service': 'svc',
+      'data.fdaId': 'fdaA',
+      'data.servicePath': '/servicepath',
+    });
+  });
+
   test('throws FDANotFound when FDA does not exist', async () => {
     mongoMocks.retrieveFDA.mockResolvedValue(undefined);
     mongoMocks.retrieveFDAs.mockResolvedValue([]);


### PR DESCRIPTION
Related Issue: #169 

This fixes FDA deletion when Minio has no matching objects, so Sliding Window and fresh FDAs can be removed cleanly.