### PR TITLE
Issue GET data with query params

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
 - Add: Pentaho CDA backward compatibility now supports browser-style `GET /plugin/cda/api/doQuery` with query params, including `outputType` (`json`, `csv`, `xls`) (#108)
-- Add: Existing data endpoints now support both context styles (FIWARE headers or query params for service/servicePath) on the same URL (`GET /{visibility}/fdas/{fdaId}/das/{daId}/data` and `GET /{visibility}/fdas/{fdaId}/data`), returning `409 RequestStyleConflict` when both styles are mixed in the same request (#175)
+- Add: existing data endpoints now support both context styles (FIWARE headers or query params for service/servicePath) on the same URL (`GET /{visibility}/fdas/{fdaId}/das/{daId}/data` and `GET /{visibility}/fdas/{fdaId}/data`), returning `409 RequestStyleConflict` when both styles are mixed in the same request (#175)
 - Fix: FDA deletion now ignores missing Minio objects so Sliding Window and fresh FDAs can be removed even when no files were uploaded (#169)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
 - Add: Pentaho CDA backward compatibility now supports browser-style `GET /plugin/cda/api/doQuery` with query params, including `outputType` (`json`, `csv`, `xls`) (#108)
-- Add: New query-style endpoints `GET /data/da` and `GET /data/fda` (#175)
+- Add: Existing data endpoints now support both context styles (FIWARE headers or query params for service/servicePath) on the same URL (`GET /{visibility}/fdas/{fdaId}/das/{daId}/data` and `GET /{visibility}/fdas/{fdaId}/data`), returning `409 RequestStyleConflict` when both styles are mixed in the same request (#175)
 - Fix: FDA deletion now ignores missing Minio objects so Sliding Window and fresh FDAs can be removed even when no files were uploaded (#169)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Add: Pentaho CDA backward compatibility now supports browser-style `GET /plugin/cda/api/doQuery` with query params, including `outputType` (`json`, `csv`, `xls`) (#108)
+- Add: New query-style endpoints `GET /data/da` and `GET /data/fda` (#175)

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -32,8 +32,6 @@
         -   [Delete DA](#delete-da-delete-visibilityfdasfdaiddasdaid)
     -   [Data operations](#data-operations)
         -   [Data query](#data-query-get-visibilityfdasfdaiddasdaiddata)
-        -   [Query-style Data Access query](#query-style-data-access-query-get-datada)
-        -   [Query-style FDA data query](#query-style-fda-data-query-get-datafda)
         -   [Query (Pentaho CDA legacy support)](#query-plugincdaapidoquery-pentaho-cda-legacy-support)
 -   [Navigation](#-navigation)
 
@@ -1576,7 +1574,8 @@ _**Content negotiation and serialization notes**_
 -   In query-style context, response format is controlled by `outputType` query parameter.
 -   This endpoint requires `FDA_ROLE_SYNCQUERIES=true` in the API instance.
 -   In query-style context, no additional query parameters are allowed besides `service`, `servicePath`, and
-    `outputType`.
+    `outputType`; if the client attempts to send any other query parameter, the API returns `400 BadRequest` with
+    `FDA fresh query does not accept query parameters`.
 -   With `Accept: application/x-ndjson` and `Accept: text/csv`, results are streamed incrementally from PostgreSQL using
     a cursor.
 

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -1571,7 +1571,8 @@ _**Response code**_
 
 _**Content negotiation and serialization notes**_
 
--   In header-style context, response format is negotiated through the `Accept` header.
+-   In header-style context, response format is negotiated through the `Accept` header (using the
+    [standard HTTP content negotiation mechanism](https://datatracker.ietf.org/doc/html/rfc2616#section-12)).
 -   In query-style context, response format is controlled by `outputType` query parameter.
 -   This endpoint requires `FDA_ROLE_SYNCQUERIES=true` in the API instance.
 -   In query-style context, no additional query parameters are allowed besides `service`, `servicePath`, and

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -97,7 +97,7 @@ All error responses follow this structure:
 | 409  | Conflict              | `FDAUnavailable`            | FDA `exampleId` is not queryable yet because the first fetch has not completed.                                                                                                                                                                                                                                    |
 | 409  | Conflict              | `FDANotOnlyFresh`           | The FDA is cached (`cached=true`) and cannot be queried through `GET /{visibility}/fdas/{fdaId}/data`; use a DA instead.                                                                                                                                                                                           |
 | 409  | Conflict              | `FDAOnlyFresh`              | The FDA was created with `cached=false`, so it does not allow DAs nor cached DA queries.                                                                                                                                                                                                                           |
-| 409  | Conflict              | `RequestStyleConflict`      | The request mixes query-style URL parameters (`/data/da` or `/data/fda`) with legacy `Fiware-Service`/`Fiware-ServicePath` headers. Use only one style per request.                                                                                                                                                |
+| 409  | Conflict              | `RequestStyleConflict`      | The request mixes query-style context (`service`, `servicePath` in query params) with legacy `Fiware-Service`/`Fiware-ServicePath` headers in the same data-query URL. Use only one style per request.                                                                                                             |
 | 409  | Conflict              | `DatasourceInUse`           | Attempted to delete a datasource that is currently referenced by one or more FDAs in the same `Fiware-Service`.                                                                                                                                                                                                    |
 | 429  | Too Many Requests     | `TooManyFreshQueries`       | The number of concurrent direct fresh FDA queries exceeded `FDA_MAX_CONCURRENT_FRESH_QUERIES`.                                                                                                                                                                                                                     |
 | 500  | Internal Server Error | `S3ServerError`             | An error occurred in the S3 object storage component.                                                                                                                                                                                                                                                              |
@@ -1543,14 +1543,25 @@ _**Request path parameters**_
 
 _**Request query parameters**_
 
-None. Any query string parameter is rejected with `400 BadRequest`.
+The endpoint supports two request styles:
+
+| Parameter     | Optional | Description                                                                                             | Example        |
+| ------------- | -------- | ------------------------------------------------------------------------------------------------------- | -------------- |
+| `service`     | ✓        | Tenant or service. Required when using query-style context (instead of FIWARE headers).                 | `trantor`      |
+| `servicePath` | ✓        | NGSI hierarchical service path. Required when using query-style context (instead of FIWARE headers).    | `/servicePath` |
+| `outputType`  | ✓        | Output format for query-style context. Allowed values: `json`, `ndjson`, `csv`, `xls`. Default: `json`. | `csv`          |
+
+When using header-style context, any query string parameter is rejected with `400 BadRequest`.
 
 _**Request headers**_
 
-| Header               | Optional | Description                                                          | Example        |
-| -------------------- | -------- | -------------------------------------------------------------------- | -------------- |
-| `Fiware-Service`     |          | Tenant or service, using the common mechanism of the FIWARE platform | `trantor`      |
-| `Fiware-ServicePath` |          | NGSI hierarchical service path. Must match the FDA's stored path.    | `/servicePath` |
+| Header               | Optional | Description                                              | Example        |
+| -------------------- | -------- | -------------------------------------------------------- | -------------- |
+| `Fiware-Service`     | ✓        | Tenant or service for header-style context.              | `trantor`      |
+| `Fiware-ServicePath` | ✓        | NGSI hierarchical service path for header-style context. | `/servicePath` |
+
+`Fiware-Service` and `Fiware-ServicePath` cannot be mixed with query-style context (`service`, `servicePath` query
+params). If both styles are present, API returns `409 RequestStyleConflict`.
 
 _**Response code**_
 
@@ -1560,8 +1571,11 @@ _**Response code**_
 
 _**Content negotiation and serialization notes**_
 
--   Response format is negotiated only through the `Accept` header.
+-   In header-style context, response format is negotiated through the `Accept` header.
+-   In query-style context, response format is controlled by `outputType` query parameter.
 -   This endpoint requires `FDA_ROLE_SYNCQUERIES=true` in the API instance.
+-   In query-style context, no additional query parameters are allowed besides `service`, `servicePath`, and
+    `outputType`.
 -   With `Accept: application/x-ndjson` and `Accept: text/csv`, results are streamed incrementally from PostgreSQL using
     a cursor.
 
@@ -1573,36 +1587,10 @@ curl -i -X GET "http://localhost:8080/public/fdas/fda_live_alarms/data" \
     -H "Fiware-ServicePath: /servicePath"
 ```
 
-#### Query-style FDA data query `GET /data/fda`
-
-Runs the FDA base query directly against PostgreSQL (same behavior as `GET /{visibility}/fdas/{fdaId}/data`) using URL
-query parameters instead of tenant headers and scoped path.
-
-_**Request query parameters**_
-
-| Parameter     | Optional | Description                                                                     | Example           |
-| ------------- | -------- | ------------------------------------------------------------------------------- | ----------------- |
-| `service`     |          | Tenant or service                                                               | `trantor`         |
-| `servicePath` |          | NGSI hierarchical service path                                                  | `/servicePath`    |
-| `visibility`  |          | FDA access visibility. Allowed values: `public`, `private`                      | `public`          |
-| `fdaId`       |          | Id of the `fda`                                                                 | `fda_live_alarms` |
-| `outputType`  | ✓        | Output format. Allowed values: `json`, `ndjson`, `csv`, `xls`. Default: `json`. | `csv`             |
-
-_**Request headers**_
-
-`Fiware-Service` and `Fiware-ServicePath` must not be sent with this endpoint. If they are present, API returns
-`409 RequestStyleConflict`.
-
-_**Behavior notes**_
-
--   This endpoint is always fresh and requires `FDA_ROLE_SYNCQUERIES=true`.
--   No additional query parameters are allowed besides `outputType`.
--   Response format is controlled by `outputType` query parameter.
-
-_**Example Request:**_
+_**Example Request (query-style context):**_
 
 ```bash
-curl -i -X GET "http://localhost:8080/data/fda?service=trantor&servicePath=%2FservicePath&visibility=public&fdaId=fda_live_alarms"
+curl -i -X GET "http://localhost:8080/public/fdas/fda_live_alarms/data?service=trantor&servicePath=%2FservicePath"
 ```
 
 #### Data Access query `GET /{visibility}/fdas/{fdaId}/das/{daId}/data`
@@ -1620,14 +1608,24 @@ _**Request path parameters**_
 
 _**Request query parameters**_
 
-The DA-specific parameters could be included in the query string.
+The endpoint supports two request styles:
+
+| Parameter     | Optional | Description                                                                                             | Example                  |
+| ------------- | -------- | ------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `service`     | ✓        | Tenant or service. Required when using query-style context (instead of FIWARE headers).                 | `trantor`                |
+| `servicePath` | ✓        | NGSI hierarchical service path. Required when using query-style context (instead of FIWARE headers).    | `/servicePath`           |
+| `outputType`  | ✓        | Output format for query-style context. Allowed values: `json`, `ndjson`, `csv`, `xls`. Default: `json`. | `csv`                    |
+| DA params     | ✓        | DA-specific parameters declared in `params`.                                                            | `pattern=%25nosignal%25` |
 
 _**Request headers**_
 
-| Header               | Optional | Description                                                          | Example        |
-| -------------------- | -------- | -------------------------------------------------------------------- | -------------- |
-| `Fiware-Service`     |          | Tenant or service, using the common mechanism of the FIWARE platform | `trantor`      |
-| `Fiware-ServicePath` |          | NGSI hierarchical service path. Must match the FDA's stored path.    | `/servicePath` |
+| Header               | Optional | Description                                              | Example        |
+| -------------------- | -------- | -------------------------------------------------------- | -------------- |
+| `Fiware-Service`     | ✓        | Tenant or service for header-style context.              | `trantor`      |
+| `Fiware-ServicePath` | ✓        | NGSI hierarchical service path for header-style context. | `/servicePath` |
+
+`Fiware-Service` and `Fiware-ServicePath` cannot be mixed with query-style context (`service`, `servicePath` query
+params). If both styles are present, API returns `409 RequestStyleConflict`.
 
 _**Request payload**_
 
@@ -1670,10 +1668,12 @@ Depends on `Accept`:
 
 _**Content negotiation and serialization notes**_
 
--   Response format is negotiated only through the `Accept` header (using the
+-   In header-style context, response format is negotiated through the `Accept` header (using the
     [standard HTTP content negotiation mechanism](https://datatracker.ietf.org/doc/html/rfc2616#section-12)).
--   If `Accept` does not include a supported format, the API returns `406 NotAcceptable`.
+-   In query-style context, response format is controlled by `outputType` query parameter.
+-   If `Accept` does not include a supported format in header-style context, the API returns `406 NotAcceptable`.
 -   Unsupported query fields are rejected with `400 BadRequest`.
+-   `fresh` query field is rejected with `400 BadRequest`.
 -   Date values are normalized to strings (ISO 8601) before JSON/NDJSON/CSV serialization.
 -   Integer database values are normalized to numeric JSON values.
 -   With `Accept: text/csv` and `Accept: application/x-ndjson`, responses are streamed.
@@ -1727,50 +1727,10 @@ curl -i -X GET "http://localhost:8080/public/fdas/fda_alarms/das/da_filter_by_na
   -H "Fiware-ServicePath: /servicePath"
 ```
 
-#### Query-style Data Access query `GET /data/da`
-
-Runs a stored parameterized DA query (same behavior as `GET /{visibility}/fdas/{fdaId}/das/{daId}/data`) using URL query
-parameters instead of tenant headers and scoped path.
-
-_**Request query parameters**_
-
-| Parameter     | Optional | Description                                                                     | Example                  |
-| ------------- | -------- | ------------------------------------------------------------------------------- | ------------------------ |
-| `service`     |          | Tenant or service                                                               | `trantor`                |
-| `servicePath` |          | NGSI hierarchical service path                                                  | `/servicePath`           |
-| `visibility`  |          | FDA access visibility. Allowed values: `public`, `private`                      | `public`                 |
-| `fdaId`       |          | Id of the `fda`                                                                 | `fda_alarms`             |
-| `daId`        |          | Id of the `da`                                                                  | `da_filter_by_name`      |
-| `outputType`  | ✓        | Output format. Allowed values: `json`, `ndjson`, `csv`, `xls`. Default: `json`. | `csv`                    |
-| DA params     | ✓        | DA-specific parameters declared in `params`                                     | `pattern=%25nosignal%25` |
-
-_**Request headers**_
-
-`Fiware-Service` and `Fiware-ServicePath` must not be sent with this endpoint. If they are present, API returns
-`409 RequestStyleConflict`.
-
-_**Behavior notes**_
-
--   `outputType` and `fresh` query fields are rejected with `400 BadRequest`.
--   `fresh` query field is rejected with `400 BadRequest`.
--   Response format is controlled by `outputType` query parameter.
-
-_**Example Request:**_
+_**Example Request (query-style context):**_
 
 ```bash
-curl -i -X GET "http://localhost:8080/data/da?service=trantor&servicePath=%2FservicePath&visibility=public&fdaId=fda_alarms&daId=da_filter_by_name&pattern=%25nosignal%25"
-```
-
-_**Example Response:**_
-
-```json
-[
-    {
-        "entityid": "alarm_nosignal_001",
-        "__NAME__": "nosignal_001",
-        "__SEVERITY__": "medium"
-    }
-]
+curl -i -X GET "http://localhost:8080/public/fdas/fda_alarms/das/da_filter_by_name/data?service=trantor&servicePath=%2FservicePath&pattern=%25nosignal%25"
 ```
 
 _**Example Request (CSV output):**_

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -32,6 +32,8 @@
         -   [Delete DA](#delete-da-delete-visibilityfdasfdaiddasdaid)
     -   [Data operations](#data-operations)
         -   [Data query](#data-query-get-visibilityfdasfdaiddasdaiddata)
+        -   [Query-style Data Access query](#query-style-data-access-query-get-datada)
+        -   [Query-style FDA data query](#query-style-fda-data-query-get-datafda)
         -   [Query (Pentaho CDA legacy support)](#query-plugincdaapidoquery-pentaho-cda-legacy-support)
 -   [Navigation](#-navigation)
 
@@ -95,6 +97,7 @@ All error responses follow this structure:
 | 409  | Conflict              | `FDAUnavailable`            | FDA `exampleId` is not queryable yet because the first fetch has not completed.                                                                                                                                                                                                                                    |
 | 409  | Conflict              | `FDANotOnlyFresh`           | The FDA is cached (`cached=true`) and cannot be queried through `GET /{visibility}/fdas/{fdaId}/data`; use a DA instead.                                                                                                                                                                                           |
 | 409  | Conflict              | `FDAOnlyFresh`              | The FDA was created with `cached=false`, so it does not allow DAs nor cached DA queries.                                                                                                                                                                                                                           |
+| 409  | Conflict              | `RequestStyleConflict`      | The request mixes query-style URL parameters (`/data/da` or `/data/fda`) with legacy `Fiware-Service`/`Fiware-ServicePath` headers. Use only one style per request.                                                                                                                                                |
 | 409  | Conflict              | `DatasourceInUse`           | Attempted to delete a datasource that is currently referenced by one or more FDAs in the same `Fiware-Service`.                                                                                                                                                                                                    |
 | 429  | Too Many Requests     | `TooManyFreshQueries`       | The number of concurrent direct fresh FDA queries exceeded `FDA_MAX_CONCURRENT_FRESH_QUERIES`.                                                                                                                                                                                                                     |
 | 500  | Internal Server Error | `S3ServerError`             | An error occurred in the S3 object storage component.                                                                                                                                                                                                                                                              |
@@ -1570,6 +1573,38 @@ curl -i -X GET "http://localhost:8080/public/fdas/fda_live_alarms/data" \
     -H "Fiware-ServicePath: /servicePath"
 ```
 
+#### Query-style FDA data query `GET /data/fda`
+
+Runs the FDA base query directly against PostgreSQL (same behavior as `GET /{visibility}/fdas/{fdaId}/data`) using URL
+query parameters instead of tenant headers and scoped path.
+
+_**Request query parameters**_
+
+| Parameter     | Optional | Description                                                                     | Example           |
+| ------------- | -------- | ------------------------------------------------------------------------------- | ----------------- |
+| `service`     |          | Tenant or service                                                               | `trantor`         |
+| `servicePath` |          | NGSI hierarchical service path                                                  | `/servicePath`    |
+| `visibility`  |          | FDA access visibility. Allowed values: `public`, `private`                      | `public`          |
+| `fdaId`       |          | Id of the `fda`                                                                 | `fda_live_alarms` |
+| `outputType`  | ✓        | Output format. Allowed values: `json`, `ndjson`, `csv`, `xls`. Default: `json`. | `csv`             |
+
+_**Request headers**_
+
+`Fiware-Service` and `Fiware-ServicePath` must not be sent with this endpoint. If they are present, API returns
+`409 RequestStyleConflict`.
+
+_**Behavior notes**_
+
+-   This endpoint is always fresh and requires `FDA_ROLE_SYNCQUERIES=true`.
+-   No additional query parameters are allowed besides `outputType`.
+-   Response format is controlled by `outputType` query parameter.
+
+_**Example Request:**_
+
+```bash
+curl -i -X GET "http://localhost:8080/data/fda?service=trantor&servicePath=%2FservicePath&visibility=public&fdaId=fda_live_alarms"
+```
+
 #### Data Access query `GET /{visibility}/fdas/{fdaId}/das/{daId}/data`
 
 Runs a stored parameterized query for the selected DA. The request path declares the access visibility and the query
@@ -1690,6 +1725,40 @@ _**Example Request (with parameters):**_
 curl -i -X GET "http://localhost:8080/public/fdas/fda_alarms/das/da_filter_by_name/data?pattern=%25nosignal%25" \
   -H "Fiware-Service: trantor" \
   -H "Fiware-ServicePath: /servicePath"
+```
+
+#### Query-style Data Access query `GET /data/da`
+
+Runs a stored parameterized DA query (same behavior as `GET /{visibility}/fdas/{fdaId}/das/{daId}/data`) using URL query
+parameters instead of tenant headers and scoped path.
+
+_**Request query parameters**_
+
+| Parameter     | Optional | Description                                                                     | Example                  |
+| ------------- | -------- | ------------------------------------------------------------------------------- | ------------------------ |
+| `service`     |          | Tenant or service                                                               | `trantor`                |
+| `servicePath` |          | NGSI hierarchical service path                                                  | `/servicePath`           |
+| `visibility`  |          | FDA access visibility. Allowed values: `public`, `private`                      | `public`                 |
+| `fdaId`       |          | Id of the `fda`                                                                 | `fda_alarms`             |
+| `daId`        |          | Id of the `da`                                                                  | `da_filter_by_name`      |
+| `outputType`  | ✓        | Output format. Allowed values: `json`, `ndjson`, `csv`, `xls`. Default: `json`. | `csv`                    |
+| DA params     | ✓        | DA-specific parameters declared in `params`                                     | `pattern=%25nosignal%25` |
+
+_**Request headers**_
+
+`Fiware-Service` and `Fiware-ServicePath` must not be sent with this endpoint. If they are present, API returns
+`409 RequestStyleConflict`.
+
+_**Behavior notes**_
+
+-   `outputType` and `fresh` query fields are rejected with `400 BadRequest`.
+-   `fresh` query field is rejected with `400 BadRequest`.
+-   Response format is controlled by `outputType` query parameter.
+
+_**Example Request:**_
+
+```bash
+curl -i -X GET "http://localhost:8080/data/da?service=trantor&servicePath=%2FservicePath&visibility=public&fdaId=fda_alarms&daId=da_filter_by_name&pattern=%25nosignal%25"
 ```
 
 _**Example Response:**_

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ import {
   buildMetricsText,
   getMetricsContentType,
 } from './lib/metrics.js';
+import { FDAError } from './lib/fdaError.js';
 
 export const app = express();
 const PORT = config.port;
@@ -96,6 +97,88 @@ const DATA_ACCEPT_CONTENT_TYPE_TO_OUTPUT = {
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xls',
   'application/vnd.ms-excel': 'xls',
 };
+
+const QUERY_STYLE_DA_REQUIRED_FIELDS = [
+  'service',
+  'servicePath',
+  'visibility',
+  'fdaId',
+  'daId',
+];
+
+const QUERY_STYLE_FDA_REQUIRED_FIELDS = [
+  'service',
+  'servicePath',
+  'visibility',
+  'fdaId',
+];
+
+const QUERY_STYLE_CONTEXT_FIELDS = [...QUERY_STYLE_DA_REQUIRED_FIELDS];
+const QUERY_STYLE_OUTPUT_TYPES = ['json', 'ndjson', 'csv', 'xls'];
+
+function throwRequestStyleConflictIfMixed(req) {
+  const hasLegacyHeaders =
+    req.get('Fiware-Service') !== undefined ||
+    req.get('Fiware-ServicePath') !== undefined;
+
+  if (hasLegacyHeaders) {
+    throw new FDAError(
+      409,
+      'RequestStyleConflict',
+      'Cannot mix query-style and header-style request parameters',
+    );
+  }
+}
+
+function assertRequiredQueryFields(query, requiredFields) {
+  const missing = requiredFields.filter((field) => {
+    const value = query[field];
+    return value === undefined || value === null || value === '';
+  });
+
+  if (missing.length > 0) {
+    throw new FDAError(400, 'BadRequest', 'Missing params in the request');
+  }
+}
+
+function getOutputTypeFromAcceptHeader(req) {
+  const matched = req.accepts(DATA_CONTENT_TYPES);
+  if (!matched) {
+    throw new FDAError(
+      406,
+      'NotAcceptable',
+      'Accept header must allow application/json, application/x-ndjson, text/csv, or application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+  }
+
+  return DATA_ACCEPT_CONTENT_TYPE_TO_OUTPUT[matched];
+}
+
+function getQueryStyleOutputType(query) {
+  const rawOutputType = query.outputType ?? DEFAULT_OUTPUT_TYPE;
+
+  if (!QUERY_STYLE_OUTPUT_TYPES.includes(rawOutputType)) {
+    throw new FDAError(
+      400,
+      'BadRequest',
+      `Invalid outputType '${rawOutputType}'. Allowed values: ${QUERY_STYLE_OUTPUT_TYPES.join(', ')}`,
+    );
+  }
+
+  return rawOutputType;
+}
+
+function splitDaQueryStyleParams(query) {
+  const queryParams = { ...query };
+
+  for (const reservedField of QUERY_STYLE_CONTEXT_FIELDS) {
+    delete queryParams[reservedField];
+  }
+
+  delete queryParams.outputType;
+
+  return queryParams;
+}
 
 async function sendRowsByOutputType(res, rows, outputType) {
   if (outputType === 'csv') {
@@ -555,6 +638,80 @@ app.get('/:visibility/fdas/:fdaId/data', async (req, res) => {
   });
 
   return sendRowsByOutputType(res, rows, outputType);
+});
+
+app.get('/data/da', async (req, res) => {
+  throwRequestStyleConflictIfMixed(req);
+  validateForbiddenFieldsQuery(req.query, ['fresh']);
+  assertRequiredQueryFields(req.query, QUERY_STYLE_DA_REQUIRED_FIELDS);
+
+  const { service, servicePath, visibility, fdaId, daId } = req.query;
+  const outputType = getQueryStyleOutputType(req.query);
+  const params = {
+    fdaId,
+    daId,
+    ...splitDaQueryStyleParams(req.query),
+  };
+
+  if (outputType === 'ndjson' || outputType === 'csv') {
+    return executeQueryStream({
+      service,
+      visibility,
+      servicePath,
+      params,
+      req,
+      res,
+      format: outputType,
+    });
+  }
+
+  const rows = await executeQuery({
+    service,
+    visibility,
+    servicePath,
+    params,
+  });
+
+  return sendRowsByOutputType(res, rows, outputType);
+});
+
+app.get('/data/fda', async (req, res) => {
+  throwRequestStyleConflictIfMixed(req);
+  validateForbiddenFieldsQuery(req.query, ['fresh']);
+  assertRequiredQueryFields(req.query, QUERY_STYLE_FDA_REQUIRED_FIELDS);
+
+  const { service, servicePath, visibility, fdaId, outputType, ...rest } =
+    req.query;
+  if (Object.keys(rest).length > 0) {
+    throw new FDAError(
+      400,
+      'BadRequest',
+      'FDA fresh query does not accept query parameters',
+    );
+  }
+
+  const queryStyleOutputType = getQueryStyleOutputType({ outputType });
+
+  if (queryStyleOutputType === 'ndjson' || queryStyleOutputType === 'csv') {
+    return executeFDAQueryStream({
+      service,
+      visibility,
+      servicePath,
+      fdaId,
+      req,
+      res,
+      format: queryStyleOutputType,
+    });
+  }
+
+  const rows = await executeFDAQuery({
+    service,
+    visibility,
+    servicePath,
+    fdaId,
+  });
+
+  return sendRowsByOutputType(res, rows, queryStyleOutputType);
 });
 
 app.post('/datasources', async (req, res) => {

--- a/src/index.js
+++ b/src/index.js
@@ -98,46 +98,15 @@ const DATA_ACCEPT_CONTENT_TYPE_TO_OUTPUT = {
   'application/vnd.ms-excel': 'xls',
 };
 
-const QUERY_STYLE_DA_REQUIRED_FIELDS = [
-  'service',
-  'servicePath',
-  'visibility',
-  'fdaId',
-  'daId',
-];
-
-const QUERY_STYLE_FDA_REQUIRED_FIELDS = [
-  'service',
-  'servicePath',
-  'visibility',
-  'fdaId',
-];
-
-const QUERY_STYLE_CONTEXT_FIELDS = [...QUERY_STYLE_DA_REQUIRED_FIELDS];
 const QUERY_STYLE_OUTPUT_TYPES = ['json', 'ndjson', 'csv', 'xls'];
 
-function throwRequestStyleConflictIfMixed(req) {
-  const hasLegacyHeaders =
-    req.get('Fiware-Service') !== undefined ||
-    req.get('Fiware-ServicePath') !== undefined;
-
-  if (hasLegacyHeaders) {
+function throwRequestStyleConflictIfMixed(hasHeaderContext, hasQueryContext) {
+  if (hasHeaderContext && hasQueryContext) {
     throw new FDAError(
       409,
       'RequestStyleConflict',
       'Cannot mix query-style and header-style request parameters',
     );
-  }
-}
-
-function assertRequiredQueryFields(query, requiredFields) {
-  const missing = requiredFields.filter((field) => {
-    const value = query[field];
-    return value === undefined || value === null || value === '';
-  });
-
-  if (missing.length > 0) {
-    throw new FDAError(400, 'BadRequest', 'Missing params in the request');
   }
 }
 
@@ -171,13 +140,47 @@ function getQueryStyleOutputType(query) {
 function splitDaQueryStyleParams(query) {
   const queryParams = { ...query };
 
-  for (const reservedField of QUERY_STYLE_CONTEXT_FIELDS) {
-    delete queryParams[reservedField];
-  }
-
+  delete queryParams.service;
+  delete queryParams.servicePath;
   delete queryParams.outputType;
 
   return queryParams;
+}
+
+function resolveServiceContextFromRequest(req) {
+  const headerService = req.get('Fiware-Service');
+  const headerServicePath = req.get('Fiware-ServicePath');
+  const queryService = req.query.service;
+  const queryServicePath = req.query.servicePath;
+
+  const hasHeaderContext =
+    headerService !== undefined || headerServicePath !== undefined;
+  const hasQueryContext =
+    queryService !== undefined || queryServicePath !== undefined;
+
+  throwRequestStyleConflictIfMixed(hasHeaderContext, hasQueryContext);
+
+  if (hasQueryContext) {
+    if (!queryService || !queryServicePath) {
+      throw new FDAError(400, 'BadRequest', 'Missing params in the request');
+    }
+
+    return {
+      style: 'query',
+      service: queryService,
+      servicePath: queryServicePath,
+    };
+  }
+
+  if (!headerService || !headerServicePath) {
+    throw new FDAError(400, 'BadRequest', 'Missing params in the request');
+  }
+
+  return {
+    style: 'header',
+    service: headerService,
+    servicePath: headerServicePath,
+  };
 }
 
 async function sendRowsByOutputType(res, rows, outputType) {
@@ -534,24 +537,20 @@ app.delete('/:visibility/fdas/:fdaId/das/:daId', async (req, res) => {
 
 app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
   const { visibility, fdaId, daId } = req.params;
-  const service = req.get('Fiware-Service');
-  const servicePath = req.get('Fiware-ServicePath');
+  const { service, servicePath, style } = resolveServiceContextFromRequest(req);
 
-  validateForbiddenFieldsQuery(req.query, ['outputType', 'fresh']);
+  let outputType;
+  let queryParams;
 
-  const matched = req.accepts(DATA_CONTENT_TYPES);
-  if (!matched) {
-    return res.status(406).json({
-      error: 'NotAcceptable',
-      description:
-        'Accept header must allow application/json, application/x-ndjson, text/csv, or application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    });
+  if (style === 'query') {
+    validateForbiddenFieldsQuery(req.query, ['fresh']);
+    outputType = getQueryStyleOutputType(req.query);
+    queryParams = splitDaQueryStyleParams(req.query);
+  } else {
+    validateForbiddenFieldsQuery(req.query, ['outputType', 'fresh']);
+    outputType = getOutputTypeFromAcceptHeader(req);
+    queryParams = { ...req.query };
   }
-
-  const outputType = DATA_ACCEPT_CONTENT_TYPE_TO_OUTPUT[matched];
-
-  const queryParams = { ...req.query };
-  delete queryParams.outputType;
 
   if (!fdaId || !daId || !service || !servicePath || !visibility) {
     return res.status(400).json({
@@ -590,26 +589,35 @@ app.get('/:visibility/fdas/:fdaId/das/:daId/data', async (req, res) => {
 
 app.get('/:visibility/fdas/:fdaId/data', async (req, res) => {
   const { visibility, fdaId } = req.params;
-  const service = req.get('Fiware-Service');
-  const servicePath = req.get('Fiware-ServicePath');
+  const { service, servicePath, style } = resolveServiceContextFromRequest(req);
 
-  if (Object.keys(req.query).length > 0) {
-    return res.status(400).json({
-      error: 'BadRequest',
-      description: 'FDA fresh query does not accept query parameters',
-    });
+  let outputType;
+  if (style === 'query') {
+    validateForbiddenFieldsQuery(req.query, ['fresh']);
+    const {
+      service: _s,
+      servicePath: _sp,
+      outputType: _ot,
+      ...rest
+    } = req.query;
+    if (Object.keys(rest).length > 0) {
+      return res.status(400).json({
+        error: 'BadRequest',
+        description: 'FDA fresh query does not accept query parameters',
+      });
+    }
+
+    outputType = getQueryStyleOutputType(req.query);
+  } else {
+    if (Object.keys(req.query).length > 0) {
+      return res.status(400).json({
+        error: 'BadRequest',
+        description: 'FDA fresh query does not accept query parameters',
+      });
+    }
+
+    outputType = getOutputTypeFromAcceptHeader(req);
   }
-
-  const matched = req.accepts(DATA_CONTENT_TYPES);
-  if (!matched) {
-    return res.status(406).json({
-      error: 'NotAcceptable',
-      description:
-        'Accept header must allow application/json, application/x-ndjson, text/csv, or application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    });
-  }
-
-  const outputType = DATA_ACCEPT_CONTENT_TYPE_TO_OUTPUT[matched];
 
   if (!fdaId || !service || !servicePath || !visibility) {
     return res.status(400).json({
@@ -638,80 +646,6 @@ app.get('/:visibility/fdas/:fdaId/data', async (req, res) => {
   });
 
   return sendRowsByOutputType(res, rows, outputType);
-});
-
-app.get('/data/da', async (req, res) => {
-  throwRequestStyleConflictIfMixed(req);
-  validateForbiddenFieldsQuery(req.query, ['fresh']);
-  assertRequiredQueryFields(req.query, QUERY_STYLE_DA_REQUIRED_FIELDS);
-
-  const { service, servicePath, visibility, fdaId, daId } = req.query;
-  const outputType = getQueryStyleOutputType(req.query);
-  const params = {
-    fdaId,
-    daId,
-    ...splitDaQueryStyleParams(req.query),
-  };
-
-  if (outputType === 'ndjson' || outputType === 'csv') {
-    return executeQueryStream({
-      service,
-      visibility,
-      servicePath,
-      params,
-      req,
-      res,
-      format: outputType,
-    });
-  }
-
-  const rows = await executeQuery({
-    service,
-    visibility,
-    servicePath,
-    params,
-  });
-
-  return sendRowsByOutputType(res, rows, outputType);
-});
-
-app.get('/data/fda', async (req, res) => {
-  throwRequestStyleConflictIfMixed(req);
-  validateForbiddenFieldsQuery(req.query, ['fresh']);
-  assertRequiredQueryFields(req.query, QUERY_STYLE_FDA_REQUIRED_FIELDS);
-
-  const { service, servicePath, visibility, fdaId, outputType, ...rest } =
-    req.query;
-  if (Object.keys(rest).length > 0) {
-    throw new FDAError(
-      400,
-      'BadRequest',
-      'FDA fresh query does not accept query parameters',
-    );
-  }
-
-  const queryStyleOutputType = getQueryStyleOutputType({ outputType });
-
-  if (queryStyleOutputType === 'ndjson' || queryStyleOutputType === 'csv') {
-    return executeFDAQueryStream({
-      service,
-      visibility,
-      servicePath,
-      fdaId,
-      req,
-      res,
-      format: queryStyleOutputType,
-    });
-  }
-
-  const rows = await executeFDAQuery({
-    service,
-    visibility,
-    servicePath,
-    fdaId,
-  });
-
-  return sendRowsByOutputType(res, rows, queryStyleOutputType);
 });
 
 app.post('/datasources', async (req, res) => {

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -44,6 +44,7 @@ import { registerDaParamsIntegrationTests } from './suites/daParams.integration.
 import { registerFdaVariantsIntegrationTests } from './suites/fdaVariants.integration.tests.js';
 import { registerDaCrudIntegrationTests } from './suites/daCrud.integration.tests.js';
 import { registerFreshQueriesIntegrationTests } from './suites/freshQueries.integration.tests.js';
+import { registerQueryStyleDataIntegrationTests } from './suites/queryStyleData.integration.tests.js';
 import { registerVisibilityConstraintsIntegrationTests } from './suites/visibilityConstraints.integration.tests.js';
 import { registerCdaCompatibilityIntegrationTests } from './suites/cdaCompatibility.integration.tests.js';
 import { registerFdaLifecycleIntegrationTests } from './suites/fdaLifecycle.integration.tests.js';
@@ -53,6 +54,8 @@ import {
   httpReqRaw,
   buildDaDataUrl,
   buildFdaDataUrl,
+  buildQueryStyleDaDataUrl,
+  buildQueryStyleFdaDataUrl,
   getFreePort,
   connectWithRetry,
   waitUntilFDACompleted,
@@ -382,6 +385,18 @@ export function runFDAIntegrationSuite({ mode, label }) {
       httpReqRaw,
       waitUntilFDACompleted,
       buildDaDataUrl,
+    });
+
+    registerQueryStyleDataIntegrationTests({
+      getBaseUrl: () => baseUrl,
+      service,
+      servicePath,
+      visibility,
+      httpReq,
+      httpReqRaw,
+      buildQueryStyleDaDataUrl,
+      buildQueryStyleFdaDataUrl,
+      waitUntilFDACompleted,
     });
 
     registerFdaVariantsIntegrationTests({

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -54,8 +54,6 @@ import {
   httpReqRaw,
   buildDaDataUrl,
   buildFdaDataUrl,
-  buildQueryStyleDaDataUrl,
-  buildQueryStyleFdaDataUrl,
   getFreePort,
   connectWithRetry,
   waitUntilFDACompleted,
@@ -396,8 +394,8 @@ export function runFDAIntegrationSuite({ mode, label }) {
       getPgPort: () => pgPort,
       httpReq,
       httpReqRaw,
-      buildQueryStyleDaDataUrl,
-      buildQueryStyleFdaDataUrl,
+      buildDaDataUrl,
+      buildFdaDataUrl,
       waitUntilFDACompleted,
     });
 

--- a/test/integration/fda.integration.shared.js
+++ b/test/integration/fda.integration.shared.js
@@ -392,6 +392,8 @@ export function runFDAIntegrationSuite({ mode, label }) {
       service,
       servicePath,
       visibility,
+      getPgHost: () => pgHost,
+      getPgPort: () => pgPort,
       httpReq,
       httpReqRaw,
       buildQueryStyleDaDataUrl,

--- a/test/integration/suites/queryStyleData.integration.tests.js
+++ b/test/integration/suites/queryStyleData.integration.tests.js
@@ -22,13 +22,15 @@
 // provided in both Spanish and international law. TSOL reserves any civil or
 // criminal actions it may exercise to protect its rights.
 
-import { describe, test, expect } from '@jest/globals';
+import { describe, beforeAll, test, expect } from '@jest/globals';
 
 export function registerQueryStyleDataIntegrationTests({
   getBaseUrl,
   service,
   servicePath,
   visibility,
+  getPgHost,
+  getPgPort,
   httpReq,
   httpReqRaw,
   buildQueryStyleDaDataUrl,
@@ -38,6 +40,84 @@ export function registerQueryStyleDataIntegrationTests({
   describe('Query-style data endpoints', () => {
     const fixtureFdaId = 'fda_qs_dq_fixture';
     const fixtureDaId = 'da_qs_dq_fixture';
+
+    async function ensureDefaultDatasource(baseUrl) {
+      const createRes = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/datasources`,
+        headers: {
+          'Content-Type': 'application/json',
+          'Fiware-Service': service,
+        },
+        body: {
+          datasourceId: 'default',
+          type: 'postgres',
+          config: {
+            user: 'postgres',
+            password: 'postgres',
+            host: getPgHost(),
+            port: getPgPort(),
+            database: service,
+          },
+        },
+      });
+
+      if (createRes.status !== 200 && createRes.status !== 409) {
+        throw new Error(
+          `Failed to ensure default datasource: ${createRes.status} ${JSON.stringify(createRes.json)}`,
+        );
+      }
+    }
+
+    beforeAll(async () => {
+      const baseUrl = getBaseUrl();
+
+      await ensureDefaultDatasource(baseUrl);
+
+      const createFda = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas`,
+        headers: {
+          'Fiware-Service': service,
+          'Fiware-ServicePath': servicePath,
+        },
+        body: {
+          id: fixtureFdaId,
+          query: 'SELECT id, name, age FROM public.users ORDER BY id',
+          description: 'query-style da data fixture',
+        },
+      });
+
+      if (createFda.status !== 202) {
+        throw new Error(
+          `Failed to create query-style DA fixture FDA: ${createFda.status} ${JSON.stringify(createFda.json)}`,
+        );
+      }
+
+      await waitUntilFDACompleted({ baseUrl, service, fdaId: fixtureFdaId });
+
+      const createDa = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas/${fixtureFdaId}/das`,
+        headers: { 'Fiware-Service': service },
+        body: {
+          id: fixtureDaId,
+          description: 'query-style da filter fixture',
+          query: `
+            SELECT id, name, age
+            WHERE age > $minAge
+            ORDER BY id
+          `,
+          params: [{ name: 'minAge', type: 'Number', required: true }],
+        },
+      });
+
+      if (createDa.status !== 200) {
+        throw new Error(
+          `Failed to create query-style DA fixture: ${createDa.status} ${JSON.stringify(createDa.json)}`,
+        );
+      }
+    });
 
     test('GET /data/da supports query-style URL-only execution', async () => {
       const baseUrl = getBaseUrl();

--- a/test/integration/suites/queryStyleData.integration.tests.js
+++ b/test/integration/suites/queryStyleData.integration.tests.js
@@ -33,8 +33,8 @@ export function registerQueryStyleDataIntegrationTests({
   getPgPort,
   httpReq,
   httpReqRaw,
-  buildQueryStyleDaDataUrl,
-  buildQueryStyleFdaDataUrl,
+  buildDaDataUrl,
+  buildFdaDataUrl,
   waitUntilFDACompleted,
 }) {
   describe('Query-style data endpoints', () => {
@@ -119,18 +119,15 @@ export function registerQueryStyleDataIntegrationTests({
       }
     });
 
-    test('GET /data/da supports query-style URL-only execution', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data supports query-style context in query params', async () => {
       const baseUrl = getBaseUrl();
 
       const res = await httpReq({
         method: 'GET',
-        url: buildQueryStyleDaDataUrl(baseUrl, {
+        url: buildDaDataUrl(baseUrl, servicePath, fixtureFdaId, fixtureDaId, {
           service,
           servicePath,
-          visibility,
-          fdaId: fixtureFdaId,
-          daId: fixtureDaId,
-          params: { minAge: 25 },
+          minAge: 25,
         }),
         headers: { Accept: 'application/json' },
       });
@@ -142,19 +139,16 @@ export function registerQueryStyleDataIntegrationTests({
       ]);
     });
 
-    test('GET /data/da supports outputType query param', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data supports outputType query param in query-style mode', async () => {
       const baseUrl = getBaseUrl();
 
       const res = await httpReqRaw({
         method: 'GET',
-        url: buildQueryStyleDaDataUrl(baseUrl, {
+        url: buildDaDataUrl(baseUrl, servicePath, fixtureFdaId, fixtureDaId, {
           service,
           servicePath,
-          visibility,
-          fdaId: fixtureFdaId,
-          daId: fixtureDaId,
           outputType: 'csv',
-          params: { minAge: 25 },
+          minAge: 25,
         }),
       });
 
@@ -163,18 +157,15 @@ export function registerQueryStyleDataIntegrationTests({
       expect(res.text).toContain('id,name,age');
     });
 
-    test('GET /data/da returns 409 when query-style is mixed with legacy headers', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data returns 409 when query-style is mixed with legacy headers', async () => {
       const baseUrl = getBaseUrl();
 
       const res = await httpReq({
         method: 'GET',
-        url: buildQueryStyleDaDataUrl(baseUrl, {
+        url: buildDaDataUrl(baseUrl, servicePath, fixtureFdaId, fixtureDaId, {
           service,
           servicePath,
-          visibility,
-          fdaId: fixtureFdaId,
-          daId: fixtureDaId,
-          params: { minAge: 25 },
+          minAge: 25,
         }),
         headers: {
           'Fiware-Service': service,
@@ -186,19 +177,16 @@ export function registerQueryStyleDataIntegrationTests({
       expect(res.json.error).toBe('RequestStyleConflict');
     });
 
-    test('GET /data/da rejects invalid outputType query param', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/das/{daId}/data rejects invalid outputType query param in query-style mode', async () => {
       const baseUrl = getBaseUrl();
 
       const res = await httpReq({
         method: 'GET',
-        url: buildQueryStyleDaDataUrl(baseUrl, {
+        url: buildDaDataUrl(baseUrl, servicePath, fixtureFdaId, fixtureDaId, {
           service,
           servicePath,
-          visibility,
-          fdaId: fixtureFdaId,
-          daId: fixtureDaId,
           outputType: 'html',
-          params: { minAge: 25 },
+          minAge: 25,
         }),
       });
 
@@ -207,7 +195,7 @@ export function registerQueryStyleDataIntegrationTests({
       expect(res.json.description).toContain("Invalid outputType 'html'");
     });
 
-    test('GET /data/fda supports query-style URL-only execution', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/data supports query-style context in query params', async () => {
       const baseUrl = getBaseUrl();
       const fdaQueryStyleId = 'fda_query_style_direct';
 
@@ -231,12 +219,7 @@ export function registerQueryStyleDataIntegrationTests({
 
       const freshRes = await httpReq({
         method: 'GET',
-        url: buildQueryStyleFdaDataUrl(baseUrl, {
-          service,
-          servicePath,
-          visibility,
-          fdaId: fdaQueryStyleId,
-        }),
+        url: `${buildFdaDataUrl(baseUrl, servicePath, fdaQueryStyleId)}?service=${encodeURIComponent(service)}&servicePath=${encodeURIComponent(servicePath)}`,
       });
 
       expect(freshRes.status).toBe(200);
@@ -244,7 +227,7 @@ export function registerQueryStyleDataIntegrationTests({
       expect(freshRes.json.length).toBeGreaterThan(0);
     });
 
-    test('GET /data/fda supports outputType query param', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/data supports outputType query param in query-style mode', async () => {
       const baseUrl = getBaseUrl();
       const fdaQueryStyleCsvId = 'fda_query_style_csv';
 
@@ -268,13 +251,7 @@ export function registerQueryStyleDataIntegrationTests({
 
       const freshRes = await httpReqRaw({
         method: 'GET',
-        url: buildQueryStyleFdaDataUrl(baseUrl, {
-          service,
-          servicePath,
-          visibility,
-          fdaId: fdaQueryStyleCsvId,
-          outputType: 'csv',
-        }),
+        url: `${buildFdaDataUrl(baseUrl, servicePath, fdaQueryStyleCsvId)}?service=${encodeURIComponent(service)}&servicePath=${encodeURIComponent(servicePath)}&outputType=csv`,
       });
 
       expect(freshRes.status).toBe(200);
@@ -282,7 +259,7 @@ export function registerQueryStyleDataIntegrationTests({
       expect(freshRes.text).toContain('id,name,age,timeinstant,authorized');
     });
 
-    test('GET /data/fda returns 409 when query-style is mixed with legacy headers', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/data returns 409 when query-style is mixed with legacy headers', async () => {
       const baseUrl = getBaseUrl();
       const fdaConflictId = 'fda_query_style_conflict';
 
@@ -306,12 +283,7 @@ export function registerQueryStyleDataIntegrationTests({
 
       const freshRes = await httpReq({
         method: 'GET',
-        url: buildQueryStyleFdaDataUrl(baseUrl, {
-          service,
-          servicePath,
-          visibility,
-          fdaId: fdaConflictId,
-        }),
+        url: `${buildFdaDataUrl(baseUrl, servicePath, fdaConflictId)}?service=${encodeURIComponent(service)}&servicePath=${encodeURIComponent(servicePath)}`,
         headers: {
           'Fiware-Service': service,
         },
@@ -321,7 +293,7 @@ export function registerQueryStyleDataIntegrationTests({
       expect(freshRes.json.error).toBe('RequestStyleConflict');
     });
 
-    test('GET /data/fda rejects invalid outputType query param', async () => {
+    test('GET /{visibility}/fdas/{fdaId}/data rejects invalid outputType query param in query-style mode', async () => {
       const baseUrl = getBaseUrl();
       const fdaInvalidOutputTypeId = 'fda_query_style_invalid_output_type';
 
@@ -345,13 +317,7 @@ export function registerQueryStyleDataIntegrationTests({
 
       const freshRes = await httpReq({
         method: 'GET',
-        url: buildQueryStyleFdaDataUrl(baseUrl, {
-          service,
-          servicePath,
-          visibility,
-          fdaId: fdaInvalidOutputTypeId,
-          outputType: 'html',
-        }),
+        url: `${buildFdaDataUrl(baseUrl, servicePath, fdaInvalidOutputTypeId)}?service=${encodeURIComponent(service)}&servicePath=${encodeURIComponent(servicePath)}&outputType=html`,
       });
 
       expect(freshRes.status).toBe(400);

--- a/test/integration/suites/queryStyleData.integration.tests.js
+++ b/test/integration/suites/queryStyleData.integration.tests.js
@@ -1,0 +1,282 @@
+// Copyright 2025 Telefónica Soluciones de Informática y Comunicaciones de España, S.A.U.
+// PROJECT: fiware-data-access
+//
+// This software and / or computer program has been developed by Telefónica Soluciones
+// de Informática y Comunicaciones de España, S.A.U (hereinafter TSOL) and is protected
+// as copyright by the applicable legislation on intellectual property.
+//
+// It belongs to TSOL, and / or its licensors, the exclusive rights of reproduction,
+// distribution, public communication and transformation, and any economic right on it,
+// all without prejudice of the moral rights of the authors mentioned above. It is expressly
+// forbidden to decompile, disassemble, reverse engineer, sublicense or otherwise transmit
+// by any means, translate or create derivative works of the software and / or computer
+// programs, and perform with respect to all or part of such programs, any type of exploitation.
+//
+// Any use of all or part of the software and / or computer program will require the
+// express written consent of TSOL. In all cases, it will be necessary to make
+// an express reference to TSOL ownership in the software and / or computer
+// program.
+//
+// Non-fulfillment of the provisions set forth herein and, in general, any violation of
+// the peaceful possession and ownership of these rights will be prosecuted by the means
+// provided in both Spanish and international law. TSOL reserves any civil or
+// criminal actions it may exercise to protect its rights.
+
+import { describe, test, expect } from '@jest/globals';
+
+export function registerQueryStyleDataIntegrationTests({
+  getBaseUrl,
+  service,
+  servicePath,
+  visibility,
+  httpReq,
+  httpReqRaw,
+  buildQueryStyleDaDataUrl,
+  buildQueryStyleFdaDataUrl,
+  waitUntilFDACompleted,
+}) {
+  describe('Query-style data endpoints', () => {
+    const fixtureFdaId = 'fda_qs_dq_fixture';
+    const fixtureDaId = 'da_qs_dq_fixture';
+
+    test('GET /data/da supports query-style URL-only execution', async () => {
+      const baseUrl = getBaseUrl();
+
+      const res = await httpReq({
+        method: 'GET',
+        url: buildQueryStyleDaDataUrl(baseUrl, {
+          service,
+          servicePath,
+          visibility,
+          fdaId: fixtureFdaId,
+          daId: fixtureDaId,
+          params: { minAge: 25 },
+        }),
+        headers: { Accept: 'application/json' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.json).toEqual([
+        { id: '1', name: 'ana', age: '30' },
+        { id: '3', name: 'carlos', age: '40' },
+      ]);
+    });
+
+    test('GET /data/da supports outputType query param', async () => {
+      const baseUrl = getBaseUrl();
+
+      const res = await httpReqRaw({
+        method: 'GET',
+        url: buildQueryStyleDaDataUrl(baseUrl, {
+          service,
+          servicePath,
+          visibility,
+          fdaId: fixtureFdaId,
+          daId: fixtureDaId,
+          outputType: 'csv',
+          params: { minAge: 25 },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/csv');
+      expect(res.text).toContain('id,name,age');
+    });
+
+    test('GET /data/da returns 409 when query-style is mixed with legacy headers', async () => {
+      const baseUrl = getBaseUrl();
+
+      const res = await httpReq({
+        method: 'GET',
+        url: buildQueryStyleDaDataUrl(baseUrl, {
+          service,
+          servicePath,
+          visibility,
+          fdaId: fixtureFdaId,
+          daId: fixtureDaId,
+          params: { minAge: 25 },
+        }),
+        headers: {
+          'Fiware-Service': service,
+          Accept: 'application/json',
+        },
+      });
+
+      expect(res.status).toBe(409);
+      expect(res.json.error).toBe('RequestStyleConflict');
+    });
+
+    test('GET /data/da rejects invalid outputType query param', async () => {
+      const baseUrl = getBaseUrl();
+
+      const res = await httpReq({
+        method: 'GET',
+        url: buildQueryStyleDaDataUrl(baseUrl, {
+          service,
+          servicePath,
+          visibility,
+          fdaId: fixtureFdaId,
+          daId: fixtureDaId,
+          outputType: 'html',
+          params: { minAge: 25 },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.json.error).toBe('BadRequest');
+      expect(res.json.description).toContain("Invalid outputType 'html'");
+    });
+
+    test('GET /data/fda supports query-style URL-only execution', async () => {
+      const baseUrl = getBaseUrl();
+      const fdaQueryStyleId = 'fda_query_style_direct';
+
+      const createFda = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas`,
+        headers: {
+          'Fiware-Service': service,
+          'Fiware-ServicePath': servicePath,
+        },
+        body: {
+          id: fdaQueryStyleId,
+          description: 'query-style direct endpoint test',
+          query:
+            'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+          cached: false,
+        },
+      });
+
+      expect(createFda.status).toBe(202);
+
+      const freshRes = await httpReq({
+        method: 'GET',
+        url: buildQueryStyleFdaDataUrl(baseUrl, {
+          service,
+          servicePath,
+          visibility,
+          fdaId: fdaQueryStyleId,
+        }),
+      });
+
+      expect(freshRes.status).toBe(200);
+      expect(Array.isArray(freshRes.json)).toBe(true);
+      expect(freshRes.json.length).toBeGreaterThan(0);
+    });
+
+    test('GET /data/fda supports outputType query param', async () => {
+      const baseUrl = getBaseUrl();
+      const fdaQueryStyleCsvId = 'fda_query_style_csv';
+
+      const createFda = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas`,
+        headers: {
+          'Fiware-Service': service,
+          'Fiware-ServicePath': servicePath,
+        },
+        body: {
+          id: fdaQueryStyleCsvId,
+          description: 'query-style csv endpoint test',
+          query:
+            'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+          cached: false,
+        },
+      });
+
+      expect(createFda.status).toBe(202);
+
+      const freshRes = await httpReqRaw({
+        method: 'GET',
+        url: buildQueryStyleFdaDataUrl(baseUrl, {
+          service,
+          servicePath,
+          visibility,
+          fdaId: fdaQueryStyleCsvId,
+          outputType: 'csv',
+        }),
+      });
+
+      expect(freshRes.status).toBe(200);
+      expect(freshRes.headers['content-type']).toContain('text/csv');
+      expect(freshRes.text).toContain('id,name,age,timeinstant,authorized');
+    });
+
+    test('GET /data/fda returns 409 when query-style is mixed with legacy headers', async () => {
+      const baseUrl = getBaseUrl();
+      const fdaConflictId = 'fda_query_style_conflict';
+
+      const createFda = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas`,
+        headers: {
+          'Fiware-Service': service,
+          'Fiware-ServicePath': servicePath,
+        },
+        body: {
+          id: fdaConflictId,
+          description: 'query-style conflict test',
+          query:
+            'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+          cached: false,
+        },
+      });
+
+      expect(createFda.status).toBe(202);
+
+      const freshRes = await httpReq({
+        method: 'GET',
+        url: buildQueryStyleFdaDataUrl(baseUrl, {
+          service,
+          servicePath,
+          visibility,
+          fdaId: fdaConflictId,
+        }),
+        headers: {
+          'Fiware-Service': service,
+        },
+      });
+
+      expect(freshRes.status).toBe(409);
+      expect(freshRes.json.error).toBe('RequestStyleConflict');
+    });
+
+    test('GET /data/fda rejects invalid outputType query param', async () => {
+      const baseUrl = getBaseUrl();
+      const fdaInvalidOutputTypeId = 'fda_query_style_invalid_output_type';
+
+      const createFda = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas`,
+        headers: {
+          'Fiware-Service': service,
+          'Fiware-ServicePath': servicePath,
+        },
+        body: {
+          id: fdaInvalidOutputTypeId,
+          description: 'query-style invalid outputType test',
+          query:
+            'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+          cached: false,
+        },
+      });
+
+      expect(createFda.status).toBe(202);
+
+      const freshRes = await httpReq({
+        method: 'GET',
+        url: buildQueryStyleFdaDataUrl(baseUrl, {
+          service,
+          servicePath,
+          visibility,
+          fdaId: fdaInvalidOutputTypeId,
+          outputType: 'html',
+        }),
+      });
+
+      expect(freshRes.status).toBe(400);
+      expect(freshRes.json.error).toBe('BadRequest');
+      expect(freshRes.json.description).toContain("Invalid outputType 'html'");
+    });
+  });
+}

--- a/test/integration/utils/integrationTestUtils.js
+++ b/test/integration/utils/integrationTestUtils.js
@@ -213,6 +213,47 @@ export function buildFdaDataUrl(baseUrl, servicePath, fdaId) {
   return `${baseUrl}/${scope}/fdas/${encodeURIComponent(fdaId)}/data`;
 }
 
+export function buildQueryStyleDaDataUrl(
+  baseUrl,
+  { service, servicePath, visibility, fdaId, daId, outputType, params = {} },
+) {
+  const url = new URL(`${baseUrl}/data/da`);
+  url.searchParams.set('service', String(service));
+  url.searchParams.set('servicePath', String(servicePath));
+  url.searchParams.set('visibility', String(visibility));
+  url.searchParams.set('fdaId', String(fdaId));
+  url.searchParams.set('daId', String(daId));
+
+  if (outputType !== undefined) {
+    url.searchParams.set('outputType', String(outputType));
+  }
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return url.toString();
+}
+
+export function buildQueryStyleFdaDataUrl(
+  baseUrl,
+  { service, servicePath, visibility, fdaId, outputType },
+) {
+  const url = new URL(`${baseUrl}/data/fda`);
+  url.searchParams.set('service', String(service));
+  url.searchParams.set('servicePath', String(servicePath));
+  url.searchParams.set('visibility', String(visibility));
+  url.searchParams.set('fdaId', String(fdaId));
+
+  if (outputType !== undefined) {
+    url.searchParams.set('outputType', String(outputType));
+  }
+
+  return url.toString();
+}
+
 export function getFreePort() {
   return new Promise((resolve) => {
     const srv = net.createServer();

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -940,6 +940,192 @@ describe('index routes - validation and middleware branches', () => {
     expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
   });
 
+  test('supports query-style DA data endpoint GET /data/da', async () => {
+    fdaMocks.executeQuery.mockResolvedValueOnce([{ id: 1 }]);
+
+    const res = await request(app)
+      .get('/data/da')
+      .query({
+        service: 'svc',
+        servicePath: '/servicepath',
+        visibility: 'public',
+        fdaId: 'fda1',
+        daId: 'da1',
+        minAge: '18',
+      })
+      .expect(200);
+
+    expect(res.body).toEqual([{ id: 1 }]);
+    expect(fdaMocks.executeQuery).toHaveBeenCalledWith({
+      service: 'svc',
+      visibility: 'public',
+      servicePath: '/servicepath',
+      params: {
+        fdaId: 'fda1',
+        daId: 'da1',
+        minAge: '18',
+      },
+    });
+  });
+
+  test('supports query-style DA outputType from query param', async () => {
+    const res = await request(app)
+      .get('/data/da')
+      .query({
+        service: 'svc',
+        servicePath: '/servicepath',
+        visibility: 'public',
+        fdaId: 'fda1',
+        daId: 'da1',
+        minAge: '18',
+        outputType: 'csv',
+      })
+      .expect(200);
+
+    expect(res.text).toBe('streamed-csv');
+    expect(fdaMocks.executeQueryStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: 'csv',
+      }),
+    );
+    expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
+  });
+
+  test('supports query-style FDA data endpoint GET /data/fda', async () => {
+    fdaMocks.executeFDAQuery.mockResolvedValueOnce([{ id: 'fda-row' }]);
+
+    const res = await request(app)
+      .get('/data/fda')
+      .query({
+        service: 'svc',
+        servicePath: '/servicepath',
+        visibility: 'public',
+        fdaId: 'fda1',
+      })
+      .expect(200);
+
+    expect(res.body).toEqual([{ id: 'fda-row' }]);
+    expect(fdaMocks.executeFDAQuery).toHaveBeenCalledWith({
+      service: 'svc',
+      visibility: 'public',
+      servicePath: '/servicepath',
+      fdaId: 'fda1',
+    });
+  });
+
+  test('supports query-style FDA outputType from query param', async () => {
+    const res = await request(app)
+      .get('/data/fda')
+      .query({
+        service: 'svc',
+        servicePath: '/servicepath',
+        visibility: 'public',
+        fdaId: 'fda1',
+        outputType: 'csv',
+      })
+      .expect(200);
+
+    expect(res.text).toBe('streamed-fda-csv');
+    expect(fdaMocks.executeFDAQueryStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: 'csv',
+      }),
+    );
+    expect(fdaMocks.executeFDAQuery).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 for invalid query-style outputType in GET /data/da', async () => {
+    const res = await request(app)
+      .get('/data/da')
+      .query({
+        service: 'svc',
+        servicePath: '/servicepath',
+        visibility: 'public',
+        fdaId: 'fda1',
+        daId: 'da1',
+        outputType: 'html',
+      })
+      .expect(400);
+
+    expect(res.body).toEqual({
+      error: 'BadRequest',
+      description: expect.stringContaining("Invalid outputType 'html'"),
+    });
+  });
+
+  test('returns 409 when query-style DA request mixes legacy headers', async () => {
+    const res = await request(app)
+      .get('/data/da')
+      .set('Fiware-Service', 'svc')
+      .query({
+        service: 'svc',
+        servicePath: '/servicepath',
+        visibility: 'public',
+        fdaId: 'fda1',
+        daId: 'da1',
+      })
+      .expect(409);
+
+    expect(res.body.error).toBe('RequestStyleConflict');
+    expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
+    expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
+  });
+
+  test('returns 409 when query-style FDA request mixes legacy headers', async () => {
+    const res = await request(app)
+      .get('/data/fda')
+      .set('Fiware-ServicePath', '/servicepath')
+      .query({
+        service: 'svc',
+        servicePath: '/servicepath',
+        visibility: 'public',
+        fdaId: 'fda1',
+      })
+      .expect(409);
+
+    expect(res.body.error).toBe('RequestStyleConflict');
+    expect(fdaMocks.executeFDAQuery).not.toHaveBeenCalled();
+    expect(fdaMocks.executeFDAQueryStream).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 when query-style FDA request includes extra query params', async () => {
+    const res = await request(app)
+      .get('/data/fda')
+      .query({
+        service: 'svc',
+        servicePath: '/servicepath',
+        visibility: 'public',
+        fdaId: 'fda1',
+        limit: '1',
+      })
+      .expect(400);
+
+    expect(res.body).toEqual({
+      error: 'BadRequest',
+      description: 'FDA fresh query does not accept query parameters',
+    });
+    expect(fdaMocks.executeFDAQuery).not.toHaveBeenCalled();
+    expect(fdaMocks.executeFDAQueryStream).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 when required query-style fields are missing in GET /data/da', async () => {
+    const res = await request(app)
+      .get('/data/da')
+      .query({
+        service: 'svc',
+        servicePath: '/servicepath',
+        visibility: 'public',
+        fdaId: 'fda1',
+      })
+      .expect(400);
+
+    expect(res.body).toEqual({
+      error: 'BadRequest',
+      description: 'Missing params in the request',
+    });
+    expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
+  });
+
   test('covers DELETE DA route success path', async () => {
     await request(app)
       .delete('/public/fdas/fda1/das/da1')

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -940,17 +940,14 @@ describe('index routes - validation and middleware branches', () => {
     expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
   });
 
-  test('supports query-style DA data endpoint GET /data/da', async () => {
+  test('supports query-style DA variant on GET /:visibility/fdas/:fdaId/das/:daId/data', async () => {
     fdaMocks.executeQuery.mockResolvedValueOnce([{ id: 1 }]);
 
     const res = await request(app)
-      .get('/data/da')
+      .get('/public/fdas/fda1/das/da1/data')
       .query({
         service: 'svc',
         servicePath: '/servicepath',
-        visibility: 'public',
-        fdaId: 'fda1',
-        daId: 'da1',
         minAge: '18',
       })
       .expect(200);
@@ -968,15 +965,12 @@ describe('index routes - validation and middleware branches', () => {
     });
   });
 
-  test('supports query-style DA outputType from query param', async () => {
+  test('supports query-style DA outputType from query param on existing URL', async () => {
     const res = await request(app)
-      .get('/data/da')
+      .get('/public/fdas/fda1/das/da1/data')
       .query({
         service: 'svc',
         servicePath: '/servicepath',
-        visibility: 'public',
-        fdaId: 'fda1',
-        daId: 'da1',
         minAge: '18',
         outputType: 'csv',
       })
@@ -991,16 +985,14 @@ describe('index routes - validation and middleware branches', () => {
     expect(fdaMocks.executeQuery).not.toHaveBeenCalled();
   });
 
-  test('supports query-style FDA data endpoint GET /data/fda', async () => {
+  test('supports query-style FDA variant on GET /:visibility/fdas/:fdaId/data', async () => {
     fdaMocks.executeFDAQuery.mockResolvedValueOnce([{ id: 'fda-row' }]);
 
     const res = await request(app)
-      .get('/data/fda')
+      .get('/public/fdas/fda1/data')
       .query({
         service: 'svc',
         servicePath: '/servicepath',
-        visibility: 'public',
-        fdaId: 'fda1',
       })
       .expect(200);
 
@@ -1013,14 +1005,12 @@ describe('index routes - validation and middleware branches', () => {
     });
   });
 
-  test('supports query-style FDA outputType from query param', async () => {
+  test('supports query-style FDA outputType from query param on existing URL', async () => {
     const res = await request(app)
-      .get('/data/fda')
+      .get('/public/fdas/fda1/data')
       .query({
         service: 'svc',
         servicePath: '/servicepath',
-        visibility: 'public',
-        fdaId: 'fda1',
         outputType: 'csv',
       })
       .expect(200);
@@ -1034,15 +1024,12 @@ describe('index routes - validation and middleware branches', () => {
     expect(fdaMocks.executeFDAQuery).not.toHaveBeenCalled();
   });
 
-  test('returns 400 for invalid query-style outputType in GET /data/da', async () => {
+  test('returns 400 for invalid query-style outputType in DA data URL', async () => {
     const res = await request(app)
-      .get('/data/da')
+      .get('/public/fdas/fda1/das/da1/data')
       .query({
         service: 'svc',
         servicePath: '/servicepath',
-        visibility: 'public',
-        fdaId: 'fda1',
-        daId: 'da1',
         outputType: 'html',
       })
       .expect(400);
@@ -1053,16 +1040,13 @@ describe('index routes - validation and middleware branches', () => {
     });
   });
 
-  test('returns 409 when query-style DA request mixes legacy headers', async () => {
+  test('returns 409 when DA data URL mixes query-style context with legacy headers', async () => {
     const res = await request(app)
-      .get('/data/da')
+      .get('/public/fdas/fda1/das/da1/data')
       .set('Fiware-Service', 'svc')
       .query({
         service: 'svc',
         servicePath: '/servicepath',
-        visibility: 'public',
-        fdaId: 'fda1',
-        daId: 'da1',
       })
       .expect(409);
 
@@ -1071,15 +1055,13 @@ describe('index routes - validation and middleware branches', () => {
     expect(fdaMocks.executeQueryStream).not.toHaveBeenCalled();
   });
 
-  test('returns 409 when query-style FDA request mixes legacy headers', async () => {
+  test('returns 409 when FDA data URL mixes query-style context with legacy headers', async () => {
     const res = await request(app)
-      .get('/data/fda')
+      .get('/public/fdas/fda1/data')
       .set('Fiware-ServicePath', '/servicepath')
       .query({
         service: 'svc',
         servicePath: '/servicepath',
-        visibility: 'public',
-        fdaId: 'fda1',
       })
       .expect(409);
 
@@ -1088,14 +1070,12 @@ describe('index routes - validation and middleware branches', () => {
     expect(fdaMocks.executeFDAQueryStream).not.toHaveBeenCalled();
   });
 
-  test('returns 400 when query-style FDA request includes extra query params', async () => {
+  test('returns 400 when query-style FDA request includes unsupported query params', async () => {
     const res = await request(app)
-      .get('/data/fda')
+      .get('/public/fdas/fda1/data')
       .query({
         service: 'svc',
         servicePath: '/servicepath',
-        visibility: 'public',
-        fdaId: 'fda1',
         limit: '1',
       })
       .expect(400);
@@ -1108,14 +1088,11 @@ describe('index routes - validation and middleware branches', () => {
     expect(fdaMocks.executeFDAQueryStream).not.toHaveBeenCalled();
   });
 
-  test('returns 400 when required query-style fields are missing in GET /data/da', async () => {
+  test('returns 400 when query-style service context is incomplete in DA data URL', async () => {
     const res = await request(app)
-      .get('/data/da')
+      .get('/public/fdas/fda1/das/da1/data')
       .query({
         service: 'svc',
-        servicePath: '/servicepath',
-        visibility: 'public',
-        fdaId: 'fda1',
       })
       .expect(400);
 


### PR DESCRIPTION
Related Issue: #175 

This PR introduces two explicit query-style endpoints for non-legacy data retrieval:

- GET /data/da
- GET /data/fda

Instead of reusing a single GET endpoint for both behaviors, we split them intentionally to keep routing and API gateway segmentation clear and predictable.

### Follow-up proposal

Since query-style GET coverage now exists in the new endpoints, we should evaluate deprecating legacy GET /plugin/cda/api/doQuery in a future iteration, with a clear migration window and communication plan.