### PR TITLE
Fix: missing param in retrieveFDA call

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-Fix: bug creating DAs in partitioned FDAs
+Fix: bug preventing the creation of DAs for partitioned FDAs due to incorrect DA query path building (FROM clausule)
 Fix: bug deleting an FDA whose id is a prefix of another FDA in the same Fiware-ServicePath (#187)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-Fix: bug creating DAs for partitioned FDAs
+Fix: bug creating DAs in partitioned FDAs

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+Fix: bug creating DAs for partitioned FDAs

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -40,7 +40,6 @@ export async function startFetcher() {
       timeColumn,
       refreshPolicy,
       objStgConf,
-      partitionFlag = false,
     } = job.attrs.data;
     // Should agenda also log errors?
     try {
@@ -52,7 +51,6 @@ export async function startFetcher() {
         timeColumn,
         refreshPolicy,
         objStgConf,
-        partitionFlag,
       );
     } catch (e) {
       logger.error('Fetcher error: ', e);

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -1677,7 +1677,7 @@ async function createOneRowParquetSync(
     datasourceId,
   );
 
-  const oneRowQuery = buildOneRowQuery(query);
+  const oneRowQuery = buildOneRowQuery(query, timeColumn);
   await uploadTable(
     s3Client,
     bucketName,
@@ -1702,9 +1702,11 @@ async function createOneRowParquetSync(
   }
 }
 
-function buildOneRowQuery(query) {
+function buildOneRowQuery(query, timeColumn) {
   const normalizedQuery = query.trim().replace(/;+\s*$/, '');
-  return `SELECT * FROM (${normalizedQuery}) AS fda_one_row LIMIT 1`;
+  const orderBy = timeColumn ? ` ORDER BY ${timeColumn} DESC NULLS LAST` : '';
+
+  return `SELECT * FROM (${normalizedQuery}) AS fda_one_row ${orderBy} LIMIT 1`;
 }
 
 async function buildDefaultDataAccessDefinition(

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -994,7 +994,6 @@ export async function fetchFDA(
   if (refreshPolicy?.type === 'window') {
     const { refreshInterval, windowSize } = refreshPolicy.params || {};
 
-    // partitionFlag lets us know we are refreshing already existing partitioned files for performance purposes
     await agenda.every(
       refreshInterval,
       'refresh-fda',
@@ -1006,7 +1005,6 @@ export async function fetchFDA(
         timeColumn,
         refreshPolicy,
         objStgConf,
-        partitionFlag: true,
         datasourceId,
       },
       {
@@ -1174,7 +1172,6 @@ export async function updateFDA(service, fdaId, visibility, servicePath) {
     timeColumn: previous.timeColumn,
     refreshPolicy: previous.refreshPolicy,
     objStgConf: previous.objStgConf,
-    partitionFlag: true,
     datasourceId: previous.datasourceId ?? DEFAULT_DATASOURCE_ID,
   });
 
@@ -1196,7 +1193,6 @@ export async function processFDAAsync(
   timeColumn,
   refreshPolicy,
   objStgConf,
-  partitionFlag,
   datasourceId = DEFAULT_DATASOURCE_ID,
 ) {
   const storagePath = getFDAStoragePath(fdaId, servicePath);
@@ -1222,7 +1218,6 @@ export async function processFDAAsync(
       servicePath,
       timeColumn,
       objStgConf,
-      partitionFlag,
     );
 
     await updateFDAStatus(service, fdaId, servicePath, 'completed', 100);

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -880,6 +880,8 @@ export async function fetchFDA(
         timeQuery,
         normalizedServicePath,
         datasourceId,
+        timeColumn,
+        objStgConf,
       );
     } catch (err) {
       await rollbackFDAProvisioning(service, fdaId, normalizedServicePath);
@@ -894,6 +896,7 @@ export async function fetchFDA(
         fdaId,
         normalizedServicePath,
         timeColumn,
+        objStgConf,
       );
 
       await createDA(
@@ -1455,7 +1458,6 @@ async function uploadTableToObjStg(
   servicePath,
   timeColumn,
   objStgConf,
-  partitionFlag,
 ) {
   const s3Client = getS3Client(
     `${config.objstg.protocol}://${config.objstg.endpoint}`,
@@ -1474,8 +1476,8 @@ async function uploadTableToObjStg(
     await updateFDAStatus(service, fdaId, servicePath, 'transforming', 60);
 
     // DuckDB cant overwrite files in Minio, so for partitioned files we upload them in a tmp file and the move them
-    // We only do this for files that already exist (partitionFlag=true) so upload performance on partitions doesnt get affected
-    const parquetPath = partitionFlag
+    // This includes first upload because the one row parquet is also partitioned
+    const parquetPath = objStgConf?.partition
       ? getPath(bucket, 'tmp/' + path, '.parquet')
       : getPath(bucket, path, '.parquet');
 
@@ -1488,7 +1490,7 @@ async function uploadTableToObjStg(
       objStgConf?.compression,
     );
 
-    if (partitionFlag) {
+    if (objStgConf?.partition) {
       const objectsList = await listObjects(
         s3Client,
         bucket,
@@ -1665,6 +1667,8 @@ async function createOneRowParquetSync(
   query,
   servicePath,
   datasourceId,
+  timeColumn,
+  objStgConf,
 ) {
   const s3Client = getS3Client(
     `${config.objstg.protocol}://${config.objstg.endpoint}`,
@@ -1694,6 +1698,8 @@ async function createOneRowParquetSync(
       conn,
       getPath(bucketName, storagePath, '.csv'),
       parquetPath,
+      timeColumn,
+      objStgConf?.partition,
     );
     await dropFile(s3Client, bucketName, `${storagePath}.csv`);
   } finally {
@@ -1711,11 +1717,13 @@ async function buildDefaultDataAccessDefinition(
   fdaId,
   servicePath,
   timeColumn,
+  objStgConf,
 ) {
   const columns = await getFDAColumnNamesFromParquet(
     service,
     fdaId,
     servicePath,
+    objStgConf,
   );
 
   const resolvedTimeColumn = resolveDefaultDATimeColumnName(
@@ -1813,12 +1821,19 @@ function resolveDefaultDATimeColumnName(timeColumn, columns) {
   );
 }
 
-async function getFDAColumnNamesFromParquet(service, fdaId, servicePath) {
+async function getFDAColumnNamesFromParquet(
+  service,
+  fdaId,
+  servicePath,
+  objStgConf,
+) {
   const conn = await getDBConnection();
   try {
     const storagePath = getFDAStoragePath(fdaId, servicePath);
     const bucketName = getBucketNameFromService(service);
-    const parquetPath = `s3://${bucketName}/${storagePath}.parquet`;
+    const parquetPath = objStgConf?.partition
+      ? `s3://${bucketName}/${storagePath}.parquet/**/*.parquet`
+      : `s3://${bucketName}/${storagePath}.parquet`;
     const safeParquetPath = parquetPath.replace(/'/g, "''");
 
     const describeResult = await conn.run(

--- a/src/lib/utils/db.js
+++ b/src/lib/utils/db.js
@@ -574,7 +574,6 @@ export function buildDAQuery(
   userQuery,
   partition,
   servicePath,
-  status,
 ) {
   logger.debug(
     { service, fdaId, userQuery, partition },
@@ -598,7 +597,7 @@ export function buildDAQuery(
   const bucketName = getBucketNameFromService(service);
   const parquetPath = `s3://${bucketName}/${objectKey}.parquet`;
 
-  if (partition && status === 'completed') {
+  if (partition) {
     return `FROM read_parquet('${parquetPath}/**/*.parquet') ${trimmed}`;
   } else {
     return `FROM read_parquet('${parquetPath}') ${trimmed}`;
@@ -638,7 +637,7 @@ export async function validateDAQuery(
   userQuery,
   servicePath,
 ) {
-  const { objStgConf = {}, status } =
+  const { objStgConf = {} } =
     (await retrieveFDA(service, fdaId, servicePath)) || {};
   const query = buildDAQuery(
     service,
@@ -646,7 +645,6 @@ export async function validateDAQuery(
     userQuery,
     objStgConf?.partition,
     servicePath,
-    status,
   );
 
   let stmt;

--- a/src/lib/utils/db.js
+++ b/src/lib/utils/db.js
@@ -139,6 +139,7 @@ export async function runPreparedStatement(
     da.query,
     objStgConf?.partition,
     storedServicePath ?? servicePath,
+    'completed',
   );
 
   const stmt = await conn.prepare(query);
@@ -573,6 +574,7 @@ export function buildDAQuery(
   userQuery,
   partition,
   servicePath,
+  status,
 ) {
   logger.debug(
     { service, fdaId, userQuery, partition },
@@ -596,7 +598,7 @@ export function buildDAQuery(
   const bucketName = getBucketNameFromService(service);
   const parquetPath = `s3://${bucketName}/${objectKey}.parquet`;
 
-  if (partition) {
+  if (partition && status === 'completed') {
     return `FROM read_parquet('${parquetPath}/**/*.parquet') ${trimmed}`;
   } else {
     return `FROM read_parquet('${parquetPath}') ${trimmed}`;
@@ -636,13 +638,15 @@ export async function validateDAQuery(
   userQuery,
   servicePath,
 ) {
-  const { objStgConf = {} } = (await retrieveFDA(service, fdaId)) || {};
+  const { objStgConf = {}, status } =
+    (await retrieveFDA(service, fdaId, servicePath)) || {};
   const query = buildDAQuery(
     service,
     fdaId,
     userQuery,
     objStgConf?.partition,
     servicePath,
+    status,
   );
 
   let stmt;

--- a/src/lib/utils/db.js
+++ b/src/lib/utils/db.js
@@ -139,7 +139,6 @@ export async function runPreparedStatement(
     da.query,
     objStgConf?.partition,
     storedServicePath ?? servicePath,
-    'completed',
   );
 
   const stmt = await conn.prepare(query);

--- a/test/integration/suites/slidingWindows.integration.tests.js
+++ b/test/integration/suites/slidingWindows.integration.tests.js
@@ -669,6 +669,65 @@ export function registerSlidingWindowsIntegrationTests({
     }
   });
 
+  test('POST /fdas/:fdaId/das Create DA for partitioned FDA', async () => {
+    const baseUrl = getBaseUrl();
+    const daQuery = `
+      SELECT id, name, age
+      WHERE age > $minAge
+      ORDER BY id;
+    `;
+
+    const createDa = await httpReq({
+      method: 'POST',
+      url: `${baseUrl}/${visibility}/fdas/fda_refresh/das`,
+      headers: { 'Fiware-Service': service },
+      body: {
+        id: 'partitioned_da1',
+        description: 'age filter',
+        query: daQuery,
+        params: [
+          {
+            name: 'minAge',
+            type: 'Number',
+            required: true,
+          },
+        ],
+      },
+    });
+
+    if (createDa.status >= 400) {
+      console.error(
+        'POST /das failed:',
+        createDa.status,
+        createDa.json ?? createDa.text,
+      );
+    }
+    expect(createDa.status).toBe(200);
+
+    const queryRes = await httpReq({
+      method: 'GET',
+      url: buildDaDataUrl(
+        baseUrl,
+        servicePath,
+        'fda_refresh',
+        'partitioned_da1',
+        {
+          minAge: 25,
+        },
+      ),
+      headers: { 'Fiware-Service': service },
+    });
+
+    if (queryRes.status >= 400) {
+      console.error(
+        'GET /{visibility}/fdas/{fdaId}/das/{daId}/data failed:',
+        queryRes.status,
+        queryRes.json ?? queryRes.text,
+      );
+    }
+    expect(queryRes.status).toBe(200);
+  });
+
   test('PUT /fdas/:fdaId keeps only current window rows after manual update', async () => {
     const baseUrl = getBaseUrl();
     const suffix = `${Date.now()}`;

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -308,6 +308,24 @@ describe('db utils', () => {
       'SELECT * WHERE id = $1',
       false,
       '/servicepath',
+      'completed',
+    );
+
+    expect(result).toBe(
+      "FROM read_parquet('s3://my-service/servicepath/fdaA.parquet') SELECT * WHERE id = $1",
+    );
+  });
+
+  test('buildDAQuery builds query with partition using basic path when FDA isnt completed', async () => {
+    const { buildDAQuery } = await loadDbModule();
+
+    const result = buildDAQuery(
+      'my-service',
+      'fdaA',
+      'SELECT * WHERE id = $1',
+      true,
+      '/servicepath',
+      'pending',
     );
 
     expect(result).toBe(
@@ -324,6 +342,7 @@ describe('db utils', () => {
       'SELECT * WHERE id = $1',
       true,
       '/servicepath',
+      'completed',
     );
 
     expect(result).toBe(
@@ -340,6 +359,7 @@ describe('db utils', () => {
       'SELECT * WHERE id = $1',
       false,
       '/servicepath',
+      'completed',
     );
 
     expect(result).toBe(

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -308,7 +308,6 @@ describe('db utils', () => {
       'SELECT * WHERE id = $1',
       false,
       '/servicepath',
-      'completed',
     );
 
     expect(result).toBe(
@@ -325,11 +324,10 @@ describe('db utils', () => {
       'SELECT * WHERE id = $1',
       true,
       '/servicepath',
-      'pending',
     );
 
     expect(result).toBe(
-      "FROM read_parquet('s3://my-service/servicepath/fdaA.parquet') SELECT * WHERE id = $1",
+      "FROM read_parquet('s3://my-service/servicepath/fdaA.parquet/**/*.parquet') SELECT * WHERE id = $1",
     );
   });
 

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -315,22 +315,6 @@ describe('db utils', () => {
     );
   });
 
-  test('buildDAQuery builds query with partition using basic path when FDA isnt completed', async () => {
-    const { buildDAQuery } = await loadDbModule();
-
-    const result = buildDAQuery(
-      'my-service',
-      'fdaA',
-      'SELECT * WHERE id = $1',
-      true,
-      '/servicepath',
-    );
-
-    expect(result).toBe(
-      "FROM read_parquet('s3://my-service/servicepath/fdaA.parquet/**/*.parquet') SELECT * WHERE id = $1",
-    );
-  });
-
   test('buildDAQuery builds query with partition using wildcard path', async () => {
     const { buildDAQuery } = await loadDbModule();
 
@@ -340,7 +324,6 @@ describe('db utils', () => {
       'SELECT * WHERE id = $1',
       true,
       '/servicepath',
-      'completed',
     );
 
     expect(result).toBe(
@@ -357,7 +340,6 @@ describe('db utils', () => {
       'SELECT * WHERE id = $1',
       false,
       '/servicepath',
-      'completed',
     );
 
     expect(result).toBe(

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -1768,7 +1768,6 @@ describe('updateFDA', () => {
       timeColumn: undefined,
       refreshPolicy: undefined,
       objStgConf: undefined,
-      partitionFlag: true,
     });
   });
 
@@ -1807,7 +1806,6 @@ describe('updateFDA', () => {
         },
       },
       objStgConf: undefined,
-      partitionFlag: true,
     });
 
     expect(agenda.now).toHaveBeenCalledWith('clean-partition', {

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -1036,13 +1036,15 @@ describe('fetchFDA', () => {
         port: 5432,
         database: 'svc',
       },
-      'SELECT * FROM (SELECT id FROM users) AS fda_one_row LIMIT 1',
+      'SELECT * FROM (SELECT id FROM users) AS fda_one_row  ORDER BY timeinstant DESC NULLS LAST LIMIT 1',
       'servicepath/fda1',
     );
     expect(dbMocks.toParquet).toHaveBeenCalledWith(
       {},
       'svc/servicepath/fda1.csv',
       'svc/servicepath/fda1.parquet',
+      'timeinstant',
+      undefined,
     );
     expect(awsMocks.dropFile).toHaveBeenCalledWith(
       {},

--- a/test/unit/fetcher.test.js
+++ b/test/unit/fetcher.test.js
@@ -107,7 +107,6 @@ describe('fetcher', () => {
       'timeinstant',
       {},
       {},
-      false,
     );
   });
 


### PR DESCRIPTION
Missing param in `retrieveFDA` call from method `validateDAQuery` made so the FDA was never retrieved in that method. That mistake went to `buildDAQuery` where the `partition` conf was missing, using always the non partitioned S3 path.
This mistake rendered impossible to create DAs for partitioned FDAs. Adding the param to the call fixed the issue, but messed the creation of the **defaultDataAccess** in partitioned files that previously worked because it was created and cheked against the preview temp parquet fda, which never has partition.

After conversation with @GregorioBlazquez we decided the best option was to change the creation of the one row temp parquet file so the partitioned path applies.