### PR TITLE
Fix bug delete prefix fdas

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+Fix bug deleting an FDA whose id is a prefix of another FDA in the same Fiware-ServicePath.

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-Fix bug deleting an FDA whose id is a prefix of another FDA in the same Fiware-ServicePath.
+Fix: bug deleting an FDA whose id is a prefix of another FDA in the same Fiware-ServicePath (#187)

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -1307,10 +1307,14 @@ export async function deleteFDA(service, fdaId, visibility, servicePath) {
     config.objstg.pass,
   );
   // This way we remove FDAs independently of if theyre partitioned or not
-  const objPaths = await listObjects(
-    s3Client,
-    bucketName,
-    getFDAStoragePath(fdaId, targetServicePath),
+  const storagePath = getFDAStoragePath(fdaId, targetServicePath);
+  const allObjPaths = await listObjects(s3Client, bucketName, storagePath);
+  // Filter strictly to objects belonging to this FDA only, preventing
+  // accidental deletion of sibling FDAs whose IDs share a common prefix
+  // (e.g. fda_test and fda_test_1 both match the prefix "fda_test").
+  const objPaths = allObjPaths.filter(
+    (key) =>
+      key.startsWith(`${storagePath}/`) || key.startsWith(`${storagePath}.`),
   );
   await dropFiles(s3Client, bucketName, objPaths);
 
@@ -1427,11 +1431,16 @@ export async function cleanPartition(
   );
   const bucketName = getBucketNameFromService(service);
 
-  /* c8 ignore next 6 */
-  const objPaths = await listObjects(
+  /* c8 ignore next 10 */
+  const cleanPartitionStoragePath = getFDAStoragePath(fdaId, servicePath);
+  const allPartitionPaths = await listObjects(
     s3Client,
     bucketName,
-    getFDAStoragePath(fdaId, servicePath),
+    cleanPartitionStoragePath,
+  );
+  // Filter strictly to objects belonging to this FDA only (same prefix-collision guard as deleteFDA)
+  const objPaths = allPartitionPaths.filter((key) =>
+    key.startsWith(`${cleanPartitionStoragePath}/`),
   );
 
   const partitionsToRemove = [];

--- a/test/integration/suites/fdaVariants.integration.tests.js
+++ b/test/integration/suites/fdaVariants.integration.tests.js
@@ -38,6 +38,7 @@ export function registerFdaVariantsIntegrationTests({
       const baseUrl = getBaseUrl();
       const prefixFdaId = 'fda_test';
       const siblingPrefixFdaId = 'fda_test_1';
+      const siblingDaId = 'da_sibling_test';
 
       async function deleteFdaIfPresent(fdaId) {
         const deleteRes = await httpReq({
@@ -98,6 +99,21 @@ export function registerFdaVariantsIntegrationTests({
           fdaId: siblingPrefixFdaId,
         });
 
+        const createSiblingDa = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas/${siblingPrefixFdaId}/das`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+          body: {
+            id: siblingDaId,
+            query: 'SELECT id, name, age, timeinstant, authorized',
+          },
+        });
+
+        expect(createSiblingDa.status).toBe(200);
+
         const listRes = await httpReq({
           method: 'GET',
           url: `${baseUrl}/${visibility}/fdas`,
@@ -138,7 +154,7 @@ export function registerFdaVariantsIntegrationTests({
 
         const siblingDataRead = await httpReq({
           method: 'GET',
-          url: buildFdaDataUrl(baseUrl, servicePath, siblingPrefixFdaId),
+          url: `${baseUrl}/${visibility}/fdas/${siblingPrefixFdaId}/das/${siblingDaId}/data`,
           headers: {
             'Fiware-Service': service,
             'Fiware-ServicePath': servicePath,

--- a/test/integration/suites/fdaVariants.integration.tests.js
+++ b/test/integration/suites/fdaVariants.integration.tests.js
@@ -34,6 +34,137 @@ export function registerFdaVariantsIntegrationTests({
   buildFdaDataUrl,
 }) {
   describe('FDA variants', () => {
+    test('DELETE /fdas/:fdaId only removes the targeted FDA when another FDA shares its prefix', async () => {
+      const baseUrl = getBaseUrl();
+      const prefixFdaId = 'fda_test';
+      const siblingPrefixFdaId = 'fda_test_1';
+
+      async function deleteFdaIfPresent(fdaId) {
+        const deleteRes = await httpReq({
+          method: 'DELETE',
+          url: `${baseUrl}/${visibility}/fdas/${fdaId}`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+
+        expect([204, 404]).toContain(deleteRes.status);
+      }
+
+      try {
+        const createFirstFda = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+          body: {
+            id: prefixFdaId,
+            query:
+              'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+            description: 'prefix delete regression FDA 1',
+          },
+        });
+
+        expect(createFirstFda.status).toBe(202);
+
+        const createSiblingFda = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+          body: {
+            id: siblingPrefixFdaId,
+            query:
+              'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+            description: 'prefix delete regression FDA 2',
+          },
+        });
+
+        expect(createSiblingFda.status).toBe(202);
+
+        await waitUntilFDACompleted({
+          baseUrl,
+          service,
+          fdaId: prefixFdaId,
+        });
+        await waitUntilFDACompleted({
+          baseUrl,
+          service,
+          fdaId: siblingPrefixFdaId,
+        });
+
+        const listRes = await httpReq({
+          method: 'GET',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+
+        expect(listRes.status).toBe(200);
+        expect(Array.isArray(listRes.json)).toBe(true);
+        expect(listRes.json.some((fda) => fda.id === prefixFdaId)).toBe(true);
+        expect(listRes.json.some((fda) => fda.id === siblingPrefixFdaId)).toBe(
+          true,
+        );
+
+        const deleteFirstFda = await httpReq({
+          method: 'DELETE',
+          url: `${baseUrl}/${visibility}/fdas/${prefixFdaId}`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+
+        expect(deleteFirstFda.status).toBe(204);
+
+        const siblingRead = await httpReq({
+          method: 'GET',
+          url: `${baseUrl}/${visibility}/fdas/${siblingPrefixFdaId}`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+
+        expect(siblingRead.status).toBe(200);
+
+        const siblingDataRead = await httpReq({
+          method: 'GET',
+          url: buildFdaDataUrl(baseUrl, servicePath, siblingPrefixFdaId),
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+
+        expect(siblingDataRead.status).toBe(200);
+        expect(Array.isArray(siblingDataRead.json)).toBe(true);
+        expect(siblingDataRead.json).toHaveLength(3);
+
+        const deleteSiblingFda = await httpReq({
+          method: 'DELETE',
+          url: `${baseUrl}/${visibility}/fdas/${siblingPrefixFdaId}`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+
+        expect(deleteSiblingFda.status).toBe(204);
+      } finally {
+        await deleteFdaIfPresent(prefixFdaId);
+        await deleteFdaIfPresent(siblingPrefixFdaId);
+      }
+    });
+
     test('POST /fdas?defaultDataAccess=false creates FDA without default DA', async () => {
       const baseUrl = getBaseUrl();
       const disabledFdaId = 'fda_default_da_disabled';

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -2112,12 +2112,12 @@ describe('deleteFDA', () => {
       visibility: 'private',
       servicePath: '/servicepath',
     });
-    awsMocks.listObjects.mockResolvedValue(['routeTo/fdaA.parquet']);
+    awsMocks.listObjects.mockResolvedValue(['servicepath/fdaA.parquet']);
 
     await deleteFDA('svc', 'fdaA', 'private', '/servicepath');
 
     expect(awsMocks.dropFiles).toHaveBeenCalledWith({}, 'svc', [
-      'routeTo/fdaA.parquet',
+      'servicepath/fdaA.parquet',
     ]);
     expect(mongoMocks.removeFDA).toHaveBeenCalledWith(
       'svc',
@@ -2138,7 +2138,7 @@ describe('deleteFDA', () => {
       visibility: 'private',
       servicePath: '/servicepath',
     });
-    awsMocks.listObjects.mockResolvedValue(['routeTo/fdaA.parquet']);
+    awsMocks.listObjects.mockResolvedValue(['servicepath/fdaA.parquet']);
 
     await deleteFDA('service_name', 'fdaA', 'private', '/servicepath');
 
@@ -2148,7 +2148,31 @@ describe('deleteFDA', () => {
       'servicepath/fdaA',
     );
     expect(awsMocks.dropFiles).toHaveBeenCalledWith({}, 'service-name', [
-      'routeTo/fdaA.parquet',
+      'servicepath/fdaA.parquet',
+    ]);
+  });
+
+  test('deleteFDA only removes objects belonging to the target FDA, not sibling FDAs sharing a prefix', async () => {
+    mongoMocks.retrieveFDA.mockResolvedValue({
+      _id: 'mongo-id',
+      visibility: 'private',
+      servicePath: '/test',
+    });
+    // listObjects returns objects for both fda_test and fda_test_1 because S3
+    // prefix listing matches any key starting with "test/fda_test"
+    awsMocks.listObjects.mockResolvedValue([
+      'test/fda_test.parquet',
+      'test/fda_test_1.parquet',
+      'test/fda_test/year=2024/data.parquet',
+      'test/fda_test_1/year=2024/data.parquet',
+    ]);
+
+    await deleteFDA('svc', 'fda_test', 'private', '/test');
+
+    // Only objects belonging to fda_test must be dropped
+    expect(awsMocks.dropFiles).toHaveBeenCalledWith({}, 'svc', [
+      'test/fda_test.parquet',
+      'test/fda_test/year=2024/data.parquet',
     ]);
   });
 
@@ -2647,8 +2671,8 @@ describe('cleanPartition', () => {
     jest.clearAllMocks();
     awsMocks.getS3Client.mockReturnValue({});
     awsMocks.listObjects.mockResolvedValue([
-      'svc/fdaA/2020-01-01.parquet',
-      'svc/fdaA/2099-01-01.parquet',
+      'public/fdaA/2020-01-01.parquet',
+      'public/fdaA/2099-01-01.parquet',
     ]);
     awsMocks.dropFiles.mockResolvedValue(undefined);
   });
@@ -2671,7 +2695,7 @@ describe('cleanPartition', () => {
     expect(awsMocks.listObjects).toHaveBeenCalledWith({}, 'svc', 'public/fdaA');
 
     expect(awsMocks.dropFiles).toHaveBeenCalledWith({}, 'svc', [
-      'svc/fdaA/2020-01-01.parquet',
+      'public/fdaA/2020-01-01.parquet',
     ]);
   });
 
@@ -2725,7 +2749,7 @@ describe('cleanPartition', () => {
     );
 
     expect(awsMocks.dropFiles).toHaveBeenCalledWith({}, 'svc', [
-      'svc/fdaA/2020-01-01.parquet',
+      'public/fdaA/2020-01-01.parquet',
     ]);
   });
 


### PR DESCRIPTION
Related Issue: #187 

**Root cause** in fda.js: `listObjects` uses S3's `Prefix` parameter with a bare path like `test/fda_test`. S3 prefix-matching is pure string matching, so it also returns objects for `test/fda_test_1/...`, causing the sibling FDA's files to be deleted too. On the subsequent delete of `fda_test_1`, the `DeleteObjectsCommand` sends an empty `Objects` array → MinIO returns `MalformedXML`.

**Fix** — post-filter the `listObjects` result in `deleteFDA` and `cleanPartition` to only include keys that strictly belong to the target FDA:

- `key.startsWith(`${storagePath}/`)` → partitioned files inside the FDA's directory  
- `key.startsWith(`${storagePath}.`)` → non-partitioned files like `.parquet` / `.csv`