### PR TITLE
Issue multi-segment servicePath 

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Feature: consider only the first token of a multi-segment `Fiware-ServicePath` as the effective service path (e.g. `/A/B/C` → `/A`), ignoring additional tokens (#199)
 Fix: updated performance files, added performance and load/stress measurement for special use cases (new npm target "test:performance") (#159)
 Fix: bug preventing the creation of DAs for partitioned FDAs due to incorrect DA query path building (FROM clausule)
 Fix: bug deleting an FDA whose id is a prefix of another FDA in the same Fiware-ServicePath (#187)

--- a/src/lib/utils/fdaScope.js
+++ b/src/lib/utils/fdaScope.js
@@ -38,7 +38,7 @@ export function normalizeScopedServicePath(servicePath) {
     );
   }
 
-  const firstToken = normalizedServicePath.split('/').filter(Boolean)[0];
+  const firstToken = normalizedServicePath.split('/').find(Boolean);
 
   return `/${firstToken}`;
 }

--- a/src/lib/utils/fdaScope.js
+++ b/src/lib/utils/fdaScope.js
@@ -38,7 +38,9 @@ export function normalizeScopedServicePath(servicePath) {
     );
   }
 
-  return normalizedServicePath;
+  const firstToken = normalizedServicePath.split('/').filter(Boolean)[0];
+
+  return `/${firstToken}`;
 }
 
 export function getFDAStoragePath(fdaId, servicePath) {

--- a/test/integration/suites/fdaVariants.integration.tests.js
+++ b/test/integration/suites/fdaVariants.integration.tests.js
@@ -291,5 +291,87 @@ export function registerFdaVariantsIntegrationTests({
         });
       }
     });
+
+    test('Fiware-ServicePath multipath only uses first token for FDA scoping', async () => {
+      const baseUrl = getBaseUrl();
+
+      const fdaId = 'fda_multipath_scope_test';
+
+      const multiServicePath = '/A/B/C/D';
+
+      try {
+        const createFda = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': multiServicePath,
+          },
+          body: {
+            id: fdaId,
+            query:
+              'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+            description: 'multipath servicePath regression test',
+          },
+        });
+
+        expect(createFda.status).toBe(202);
+
+        await waitUntilFDACompleted({
+          baseUrl,
+          service,
+          fdaId,
+        });
+
+        const listRes = await httpReq({
+          method: 'GET',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': multiServicePath,
+          },
+        });
+
+        expect(listRes.status).toBe(200);
+        expect(Array.isArray(listRes.json)).toBe(true);
+        expect(listRes.json.some((fda) => fda.id === fdaId)).toBe(true);
+
+        const listResNormalized = await httpReq({
+          method: 'GET',
+          url: `${baseUrl}/${visibility}/fdas`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': '/A',
+          },
+        });
+
+        expect(listResNormalized.status).toBe(200);
+        expect(listResNormalized.json.some((fda) => fda.id === fdaId)).toBe(
+          true,
+        );
+
+        const dataRes = await httpReq({
+          method: 'GET',
+          url: buildFdaDataUrl(baseUrl, multiServicePath, fdaId),
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': multiServicePath,
+          },
+        });
+
+        expect(dataRes.status).toBe(200);
+        expect(Array.isArray(dataRes.json)).toBe(true);
+        expect(dataRes.json.length).toBeGreaterThan(0);
+      } finally {
+        await httpReq({
+          method: 'DELETE',
+          url: `${baseUrl}/${visibility}/fdas/${fdaId}`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': '/A',
+          },
+        });
+      }
+    });
   });
 }

--- a/test/integration/suites/fdaVariants.integration.tests.js
+++ b/test/integration/suites/fdaVariants.integration.tests.js
@@ -297,7 +297,7 @@ export function registerFdaVariantsIntegrationTests({
 
       const fdaId = 'fda_multipath_scope_test';
 
-      const multiServicePath = '/A/B/C/D';
+      const multiServicePath = servicePath + '/B/C/D';
 
       try {
         const createFda = await httpReq({
@@ -341,7 +341,7 @@ export function registerFdaVariantsIntegrationTests({
           url: `${baseUrl}/${visibility}/fdas`,
           headers: {
             'Fiware-Service': service,
-            'Fiware-ServicePath': '/A',
+            'Fiware-ServicePath': servicePath,
           },
         });
 
@@ -368,7 +368,7 @@ export function registerFdaVariantsIntegrationTests({
           url: `${baseUrl}/${visibility}/fdas/${fdaId}`,
           headers: {
             'Fiware-Service': service,
-            'Fiware-ServicePath': '/A',
+            'Fiware-ServicePath': servicePath,
           },
         });
       }

--- a/test/integration/suites/fdaVariants.integration.tests.js
+++ b/test/integration/suites/fdaVariants.integration.tests.js
@@ -352,7 +352,7 @@ export function registerFdaVariantsIntegrationTests({
 
         const dataRes = await httpReq({
           method: 'GET',
-          url: buildFdaDataUrl(baseUrl, multiServicePath, fdaId),
+          url: buildFdaDataUrl(baseUrl, servicePath, fdaId),
           headers: {
             'Fiware-Service': service,
             'Fiware-ServicePath': multiServicePath,

--- a/test/unit/fdaScope.test.js
+++ b/test/unit/fdaScope.test.js
@@ -42,6 +42,22 @@ describe('fdaScope utils', () => {
     );
   });
 
+  test('normalizeScopedServicePath keeps only first token (simple path)', () => {
+    expect(normalizeScopedServicePath('/A')).toBe('/A');
+  });
+
+  test('normalizeScopedServicePath keeps only first token (multipath)', () => {
+    expect(normalizeScopedServicePath('/A/B/C/D')).toBe('/A');
+  });
+
+  test('normalizeScopedServicePath trims input before processing', () => {
+    expect(normalizeScopedServicePath('   /A/B/C  ')).toBe('/A');
+  });
+
+  test('normalizeScopedServicePath throws for invalid format', () => {
+    expect(() => normalizeScopedServicePath('A/B/C')).toThrow();
+  });
+
   test('getFDAStoragePath throws when servicePath is root /', () => {
     expect(() => getFDAStoragePath('fdaA', '/')).toThrow();
   });


### PR DESCRIPTION
Related Issue: #199 

- ServicePath handling now only considers the first token of a multipath value (`/A/B/C` → `/A`) for internal FDA scoping.
- This aligns FDA behavior with external authorization layers where remaining tokens could be used exclusively for access control.