### PR TITLE
Fixed: timecolumn condition

### DIFF
--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -995,7 +995,7 @@ export async function fetchFDA(
 
   const timeQuery =
     datasource.type === 'postgres' &&
-    (refreshPolicy?.type !== 'none' || objStgConf?.partition)
+    (refreshPolicy?.type === 'window' || objStgConf?.partition)
       ? getTimeColumnQuery(query, timeColumn)
       : query;
 

--- a/test/integration/suites/fdaLifecycle.integration.tests.js
+++ b/test/integration/suites/fdaLifecycle.integration.tests.js
@@ -166,7 +166,6 @@ export function registerFdaLifecycleIntegrationTests({
         id: fdaId2,
         query: 'SELECT id, name, age FROM public.users ORDER BY id',
         description: 'users dataset',
-        timeColumn: 'timeinstant',
         refreshPolicy: {
           type: 'interval',
           params: {
@@ -192,7 +191,7 @@ export function registerFdaLifecycleIntegrationTests({
     });
 
     expect(completedFDA).toMatchObject({
-      query: 'SELECT timeinstant, id, name, age FROM public.users ORDER BY id',
+      query: 'SELECT id, name, age FROM public.users ORDER BY id',
       description: 'users dataset',
       status: 'completed',
       progress: 100,

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -1689,7 +1689,7 @@ describe('fetchFDA', () => {
       {
         datasourceId: 'default',
         fdaId: 'fda1',
-        query: 'SELECT timeinstant, 1',
+        query: 'SELECT 1',
         service: 'svc',
         servicePath: '/servicepath',
         timeColumn: 'timeinstant',
@@ -2680,6 +2680,43 @@ describe('fetchFDA with refresh policies', () => {
       'refresh-fda',
       expect.objectContaining({
         fdaId: 'fda1',
+        query: 'SELECT 1',
+        service: 'svc',
+        timeColumn: 'timeinstant',
+        objStgConf: undefined,
+      }),
+      {
+        skipImmediate: true,
+        unique: {
+          name: 'refresh-fda',
+          'data.service': 'svc',
+          'data.fdaId': 'fda1',
+          'data.servicePath': '/servicepath',
+        },
+      },
+    );
+  });
+
+  test('fetchFDA with window refresh policy schedules periodic job', async () => {
+    await fetchFDA(
+      'fda1',
+      'SELECT 1',
+      'svc',
+      'public',
+      '/servicepath',
+      'desc',
+      {
+        type: 'window',
+        params: { refreshInterval: '0 0 * * *', fetchSize: 'week' },
+      },
+      'timeinstant',
+    );
+
+    expect(agenda.every).toHaveBeenCalledWith(
+      '0 0 * * *',
+      'refresh-fda',
+      expect.objectContaining({
+        fdaId: 'fda1',
         query: 'SELECT timeinstant, 1',
         service: 'svc',
         timeColumn: 'timeinstant',
@@ -2762,6 +2799,18 @@ describe('fetchFDA with refresh policies', () => {
     ).rejects.toMatchObject({
       status: 400,
       type: 'InvalidServicePath',
+    });
+  });
+
+  test('fetchFDA throws when refresh policy window and no timecolumn', async () => {
+    await expect(
+      fetchFDA('fda1', 'SELECT 1', 'svc', 'public', '/servicepath', 'desc', {
+        type: 'window',
+        params: { refreshInterval: '0 0 * * *', fetchSize: 'week' },
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      type: 'InvalidParam',
     });
   });
 });


### PR DESCRIPTION
`timecolumn` conf property was required for all `refreshPolicy.type`. In reality it's only required for type `window` and for partitioned FDAs. Documentation was correct.