### PR TITLE
Implement skipBootstrap

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Fix: add skipBootstrap for FDA creation to bypass synchronous bootstrap (`createOneRowParquetSync`) and initial defaultDataAccess creation on heavy queries (#209)
 Add: support CDA-compatible JSON output format (`outputType=cda` and `Accept: application/vnd.fiware.cda+json`) for FDA data endpoints (#204)
 Add: MongoDB datasource support as a new datasource type, including connection validation, cached-only FDA support, Mongo-specific contract and full ingestion pipeline integration (#176)
 Fix: updated performance files, added performance and load/stress measurement for special use cases (new npm target "test:performance") (#159)

--- a/doc/03_api.md
+++ b/doc/03_api.md
@@ -804,6 +804,7 @@ A FDA is represented by a JSON object with the following fields:
 | `timeColumn`                                             | ✓        | string        | Required with `refreshPolicy` of type `window` and `partition`. Column in the table indicating when the data was received (date).                                                          |
 | `cached`                                                 | ✓        | boolean       | If `false`, the FDA is created as only-fresh: no parquet snapshot is maintained, no DAs are allowed, and the FDA is queried through `GET /{visibility}/fdas/{fdaId}/data`. Default `true`. |
 | `datasourceId`                                           | ✓        | string        | Datasource id used to resolve DB credentials for this FDA. If omitted, FDA uses `default`.                                                                                                 |
+| `skipBootstrap`                                          | ✓        | boolean       | If `true`, skips synchronous bootstrap during creation (one-row parquet + default DA creation). First refresh job is still scheduled. Default `false`.                                     |
 
 For MongoDB datasources, `query` is an object with the following keys:
 
@@ -978,6 +979,9 @@ _**Request query parameters**_
 | ------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `defaultDataAccess` | ✓        | Overrides the instance default and enables or disables automatic `defaultDataAccess` creation for this FDA. The default value is taken from `FDA_CREATE_DEFAULT_DATA_ACCESS`; if that env var is not set, the default is `true`. | `false` |
 
+When `skipBootstrap=true` is sent in the request body, it has priority during creation and initial `defaultDataAccess`
+generation is skipped even if this query parameter is enabled.
+
 _**Request headers**_
 
 | Header               | Optional | Description                                                          | Example            |
@@ -990,6 +994,9 @@ _**Request payload**_
 
 The payload is a JSON object containing a FDA that follows the JSON FDA representation format (described in
 [FDA payload datamodel](#fda-payload-datamodel) section).
+
+`skipBootstrap=true` is useful for heavy queries where synchronous bootstrap could delay creation. In this mode FDA
+creation returns normally and first fetch is delegated to the background job.
 
 _**Example Request:**_
 
@@ -1037,6 +1044,22 @@ curl -i -X POST http://localhost:8080/public/fdas \
         "query": "SELECT * FROM public.alarms",
         "description": "Only-fresh FDA",
         "cached": false
+    }'
+```
+
+_**Example Request with bootstrap skip:**_
+
+```bash
+curl -i -X POST "http://localhost:8080/public/fdas?defaultDataAccess=true" \
+    -H "Content-Type: application/json" \
+    -H "Fiware-Service: trantor" \
+    -H "Fiware-ServicePath: /servicePath" \
+    -d '{
+        "id": "fda_heavy_query",
+        "query": "SELECT * FROM public.very_large_table",
+        "description": "Create without synchronous bootstrap",
+        "skipBootstrap": true,
+        "cached": true
     }'
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -315,6 +315,7 @@ app.post('/:visibility/fdas', async (req, res) => {
     'objStgConf',
     'cached',
     'datasourceId',
+    'skipBootstrap',
   ]);
   const {
     id,
@@ -325,6 +326,7 @@ app.post('/:visibility/fdas', async (req, res) => {
     objStgConf,
     cached,
     datasourceId,
+    skipBootstrap,
   } = body;
   const service = req.get('Fiware-Service');
   const servicePath = req.get('Fiware-ServicePath');
@@ -342,6 +344,10 @@ app.post('/:visibility/fdas', async (req, res) => {
     cached === undefined
       ? true
       : parseBooleanQueryParam(cached, 'cached', true);
+  const skipBootstrapEnabled =
+    skipBootstrap === undefined
+      ? false
+      : parseBooleanQueryParam(skipBootstrap, 'skipBootstrap', false);
 
   if (!id || !query || !service || !servicePath || !visibility) {
     return res.status(400).json({
@@ -366,6 +372,7 @@ app.post('/:visibility/fdas', async (req, res) => {
     defaultDataAccessEnabled,
     cachedEnabled,
     datasourceId,
+    skipBootstrapEnabled,
   );
 
   return res.status(202).json({

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -975,6 +975,7 @@ export async function fetchFDA(
   defaultDataAccessEnabled,
   cached = true,
   datasourceId = DEFAULT_DATASOURCE_ID,
+  skipBootstrap = false,
 ) {
   const normalizedVisibility = normalizeVisibility(visibility);
   const normalizedServicePath = normalizeServicePath(servicePath);
@@ -1013,33 +1014,35 @@ export async function fetchFDA(
     datasourceId,
   );
 
-  if (cached) {
-    try {
-      await createOneRowParquetSync(
-        service,
-        fdaId,
-        timeQuery,
-        normalizedServicePath,
-        datasourceId,
-        timeColumn,
-        objStgConf,
-      );
-    } catch (err) {
-      await rollbackFDAProvisioning(service, fdaId, normalizedServicePath);
-      throw err;
+  if (!skipBootstrap) {
+    if (cached) {
+      try {
+        await createOneRowParquetSync(
+          service,
+          fdaId,
+          timeQuery,
+          normalizedServicePath,
+          datasourceId,
+          timeColumn,
+          objStgConf,
+        );
+      } catch (err) {
+        await rollbackFDAProvisioning(service, fdaId, normalizedServicePath);
+        throw err;
+      }
     }
-  }
 
-  await createDefaultDAIfNeeded({
-    cached,
-    defaultDataAccessEnabled,
-    service,
-    fdaId,
-    normalizedServicePath,
-    timeColumn,
-    objStgConf,
-    normalizedVisibility,
-  });
+    await createDefaultDAIfNeeded({
+      cached,
+      defaultDataAccessEnabled,
+      service,
+      fdaId,
+      normalizedServicePath,
+      timeColumn,
+      objStgConf,
+      normalizedVisibility,
+    });
+  }
 
   if (!cached) {
     return;

--- a/test/integration/suites/fdaVariants.integration.tests.js
+++ b/test/integration/suites/fdaVariants.integration.tests.js
@@ -221,6 +221,50 @@ export function registerFdaVariantsIntegrationTests({
       }
     });
 
+    test('POST /fdas with skipBootstrap=true does not create default DA even when defaultDataAccess=true', async () => {
+      const baseUrl = getBaseUrl();
+      const skipBootstrapFdaId = 'fda_skip_bootstrap';
+
+      try {
+        const createFda = await httpReq({
+          method: 'POST',
+          url: `${baseUrl}/${visibility}/fdas?defaultDataAccess=true`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+          body: {
+            id: skipBootstrapFdaId,
+            query:
+              'SELECT id, name, age, timeinstant, authorized FROM public.users ORDER BY id',
+            description: 'skip bootstrap integration test',
+            skipBootstrap: true,
+            cached: true,
+          },
+        });
+
+        expect(createFda.status).toBe(202);
+
+        const completedFDA = await waitUntilFDACompleted({
+          baseUrl,
+          service,
+          fdaId: skipBootstrapFdaId,
+        });
+
+        expect(completedFDA?.cached).toBe(true);
+        expect(completedFDA?.das || {}).toEqual({});
+      } finally {
+        await httpReq({
+          method: 'DELETE',
+          url: `${baseUrl}/${visibility}/fdas/${skipBootstrapFdaId}`,
+          headers: {
+            'Fiware-Service': service,
+            'Fiware-ServicePath': servicePath,
+          },
+        });
+      }
+    });
+
     test('POST /fdas with cached=false creates an only-fresh FDA without DAs', async () => {
       const baseUrl = getBaseUrl();
       const onlyFreshFdaId = 'fda_only_fresh';

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -1088,6 +1088,47 @@ describe('fetchFDA', () => {
     expect(agenda.every).not.toHaveBeenCalled();
   });
 
+  test('skipBootstrap=true skips bootstrap path and default DA creation', async () => {
+    await fetchFDA(
+      'fda1',
+      'SELECT id FROM users;',
+      'svc',
+      'public',
+      '/servicepath',
+      'test FDA',
+      {
+        type: 'none',
+      },
+      'timeinstant',
+      undefined,
+      true,
+      true,
+      'default',
+      true,
+    );
+
+    expect(pgMocks.uploadTable).not.toHaveBeenCalled();
+    expect(dbMocks.toParquet).not.toHaveBeenCalled();
+    expect(awsMocks.dropFile).not.toHaveBeenCalled();
+    expect(mongoMocks.storeDA).not.toHaveBeenCalled();
+    expect(mongoMocks.retrieveFDA).not.toHaveBeenCalled();
+    expect(mongoMocks.retrieveDA).not.toHaveBeenCalled();
+
+    expect(agenda.now).toHaveBeenCalledWith('refresh-fda', {
+      datasourceId: 'default',
+      fdaId: 'fda1',
+      query: 'SELECT id FROM users;',
+      service: 'svc',
+      servicePath: '/servicepath',
+      timeColumn: 'timeinstant',
+      refreshPolicy: {
+        type: 'none',
+      },
+      objStgConf: undefined,
+    });
+    expect(agenda.every).not.toHaveBeenCalled();
+  });
+
   test('creates default DA with optional filters, time range and pagination params', async () => {
     const describeRun = jest.fn().mockResolvedValue({
       getRowObjectsJson: () => [

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -400,6 +400,36 @@ describe('index routes - validation and middleware branches', () => {
       .expect(400);
   });
 
+  test('forwards skipBootstrap in POST /:visibility/fdas', async () => {
+    await request(app)
+      .post('/public/fdas')
+      .set('Fiware-Service', 'svc')
+      .set('Fiware-ServicePath', '/servicepath')
+      .send({
+        id: 'fda_skip_bootstrap',
+        query: 'SELECT 1',
+        description: 'skip bootstrap',
+        skipBootstrap: true,
+      })
+      .expect(202);
+
+    expect(fdaMocks.fetchFDA).toHaveBeenCalledWith(
+      'fda_skip_bootstrap',
+      'SELECT 1',
+      'svc',
+      'public',
+      '/servicepath',
+      'skip bootstrap',
+      { type: 'none' },
+      undefined,
+      {},
+      true,
+      true,
+      undefined,
+      true,
+    );
+  });
+
   test('returns 400 when Fiware-Service is missing in GET /:visibility/fdas/:fdaId', async () => {
     await request(app)
       .get('/public/fdas/fda1')
@@ -605,6 +635,7 @@ describe('index routes - validation and middleware branches', () => {
       true,
       true,
       undefined,
+      false,
     );
     expect(fdaMocks.updateFDA).toHaveBeenCalledWith(
       'svc',

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -189,7 +189,10 @@ function resetModuleMocks() {
         throw err;
       }
     });
-  utilsMocks.parseBooleanQueryParam.mockReset().mockReturnValue(false);
+  utilsMocks.parseBooleanQueryParam.mockImplementation(
+    (value, _name, defaultValue) =>
+      value === undefined ? defaultValue : value === true || value === 'true',
+  );
 }
 
 async function flushAsyncWork() {


### PR DESCRIPTION
Related Issue: #209 

We implemented skipBootstrap in this PR as a mitigation: it skips synchronous bootstrap/default DA creation during FDA creation, but keeps immediate refresh-fda scheduling.  
This helps with heavy-query creation latency, but it does not fully solve the underlying bootstrap design problem.  
I suggest we keep the tracking issue open and continue with a deeper change (including evaluating a LIMIT 0 metadata-first path).