### PR TITLE
Sync 1.1.2 to release/1.1.0

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,12 +1,17 @@
+1.1.2 (July 2nd, 2026)
+
+- Fix: FDA scheduled job cleanup now cancels Agenda jobs by persisted IDs (`agendaJobIds`) to prevent deleting jobs from other FDAs with the same recurring job name.
+- Migration: FDA documents now include `agendaJobIds` (`string[]`). Legacy FDAs without this field can still be deleted, but cleanup relies on runtime job lookup fallback; to guarantee deterministic cleanup in all environments, backfill `agendaJobIds` or recreate those FDAs.
+
 1.1.1 (July 1st, 2026)
 
-Fix: add skipBootstrap for FDA creation to bypass synchronous bootstrap (`createOneRowParquetSync`) and initial defaultDataAccess creation on heavy queries (#209)
-Add: support CDA-compatible JSON output format (`outputType=cda` and `Accept: application/vnd.fiware.cda+json`) for FDA data endpoints (#204)
-Add: MongoDB datasource support as a new datasource type, including connection validation, cached-only FDA support, Mongo-specific contract and full ingestion pipeline integration (#176)
-Fix: prevent recurring Agenda jobs from being overwritten across FDAs by using per-FDA recurring job identity and scheduling (#206)
-Fix: updated performance files, added performance and load/stress measurement for special use cases (new npm target "test:performance") (#159)
-Fix: bug preventing the creation of DAs for partitioned FDAs due to incorrect DA query path building (FROM clausule)
-Fix: bug deleting an FDA whose id is a prefix of another FDA in the same Fiware-ServicePath (#187)
+- Fix: add skipBootstrap for FDA creation to bypass synchronous bootstrap (`createOneRowParquetSync`) and initial defaultDataAccess creation on heavy queries (#209)
+- Add: support CDA-compatible JSON output format (`outputType=cda` and `Accept: application/vnd.fiware.cda+json`) for FDA data endpoints (#204)
+- Add: MongoDB datasource support as a new datasource type, including connection validation, cached-only FDA support, Mongo-specific contract and full ingestion pipeline integration (#176)
+- Fix: prevent recurring Agenda jobs from being overwritten across FDAs by using per-FDA recurring job identity and scheduling (#206)
+- Fix: updated performance files, added performance and load/stress measurement for special use cases (new npm target "test:performance") (#159)
+- Fix: bug preventing the creation of DAs for partitioned FDAs due to incorrect DA query path building (FROM clausule)
+- Fix: bug deleting an FDA whose id is a prefix of another FDA in the same Fiware-ServicePath (#187)
 
 1.1.0 (June 2nd, 2026)
 

--- a/doc/02_architecture.md
+++ b/doc/02_architecture.md
@@ -165,6 +165,7 @@ Each document corresponds to one FDA:
 -   **progress**: execution progress percentage (0–100)
 -   **lastFetch**: timestamp of the last fetch (ISO date)
 -   **datasourceId**: datasource identifier used to resolve source credentials (default `default` when omitted)
+-   **agendaJobIds**: array of scheduled job IDs for refresh tasks
 
 Each DA contains:
 
@@ -183,6 +184,7 @@ Each DA contains:
     "service": "fiwareService",
     "progress": 10,
     "lastFetch": null,
+    "agendaJobIds": ["6a4647d198863226b8001614"],
     "visibility": "public",
     "refreshPolicy": {
         "type": "interval",

--- a/doc/05_advanced_topics.md
+++ b/doc/05_advanced_topics.md
@@ -54,6 +54,9 @@ use the `fiware-service` value as the _database_ name.
 
 FDA can automatically create a built-in DA named `defaultDataAccess` when a new FDA is created.
 
+When `skipBootstrap=true` is used during FDA creation, synchronous bootstrap is skipped and `defaultDataAccess` is not
+created at that moment, even if default DA creation is enabled.
+
 This topic covers:
 
 -   creation rules

--- a/doc/AdvancedTopics/async_processing_and_jobs.md
+++ b/doc/AdvancedTopics/async_processing_and_jobs.md
@@ -277,6 +277,21 @@ This means:
 -   Survives restarts
 -   Can be modified dynamically
 
+### Recurring Job Lifecycle
+
+Recurring jobs are created using `agenda.create()`, configured with `repeatEvery()`, and persisted via `save()`. A
+`unique()` filter prevents duplicate recurring jobs from being created for the same FDA.
+
+When an FDA is deleted, recurring jobs are cancelled by their stored Agenda job IDs rather than by filtering on nested
+`data.*` fields.
+
+> **Compatibility note:** This project currently uses `agenda` 6.2.3 with `@agendajs/mongo-backend` 3.2.0. These
+> versions do not support partial matching on nested `data.*` fields in `agenda.cancel()`. This limitation has been
+> fixed upstream (Agenda PR #1679) and should be checked. Job IDs are therefore persisted to ensure precise cancellation
+> until the dependency is upgraded.
+>
+> -   [Agenda PR #1679 – Partial matching on data subdocuments](https://github.com/agenda/agenda/pull/1679)
+
 ---
 
 ## 9. Failure Handling & Backoff Strategies
@@ -363,9 +378,11 @@ PUT /{visibility}/fdas/:fdaId
 Flow:
 
 1. FDA metadata saved in Mongo
-2. Agenda job scheduled (`agenda.now()` for immediate fetch, `agenda.every()` for recurring)
+2. Agenda jobs scheduled:
+    - `agenda.now()` for the initial fetch
+    - recurring jobs created with `agenda.create()`, `repeatEvery()` and `unique()`
 3. HTTP `202 Accepted` returned
-4. Fetcher picks up job
+4. Fetcher picks up the job
 5. Mongo updated throughout lifecycle
 
 ### Query availability during first fetch

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fda",
   "license": "AGPL-3.0-only",
-  "version": "1.1.1-next",
+  "version": "1.1.2",
   "description": "fiware-data-access",
   "homepage": "https://github.com/telefonicaid/fiware-data-access",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fda",
   "license": "AGPL-3.0-only",
-  "version": "1.1.1",
+  "version": "1.1.1-next",
   "description": "fiware-data-access",
   "homepage": "https://github.com/telefonicaid/fiware-data-access",
   "type": "module",

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -1445,6 +1445,10 @@ async function resolveFDAAgendaJobIds(agenda, fda, servicePath) {
     return storedJobIds;
   }
 
+  if (typeof agenda.queryJobs !== 'function') {
+    return [];
+  }
+
   const trackedJobs = await Promise.all(
     ['refresh-fda-recurring', 'clean-partition-recurring'].map(async (name) => {
       const result = await agenda.queryJobs({ names: [name] });
@@ -2123,8 +2127,9 @@ async function scheduleFDAJobs({
   );
   refreshJob.repeatEvery(refreshInterval, { skipImmediate: true });
   await refreshJob.save();
-  if (refreshJob.attrs._id) {
-    agendaJobIds.push(refreshJob.attrs._id.toString());
+  const refreshJobId = refreshJob.attrs?._id ?? refreshJob._id;
+  if (refreshJobId) {
+    agendaJobIds.push(refreshJobId.toString());
   }
 
   if (windowSize) {
@@ -2146,8 +2151,10 @@ async function scheduleFDAJobs({
     );
     cleanPartitionJob.repeatEvery(refreshInterval, { skipImmediate: true });
     await cleanPartitionJob.save();
-    if (cleanPartitionJob.attrs._id) {
-      agendaJobIds.push(cleanPartitionJob.attrs._id.toString());
+    const cleanPartitionJobId =
+      cleanPartitionJob.attrs?._id ?? cleanPartitionJob._id;
+    if (cleanPartitionJobId) {
+      agendaJobIds.push(cleanPartitionJobId.toString());
     }
   }
 

--- a/src/lib/fda.js
+++ b/src/lib/fda.js
@@ -62,6 +62,7 @@ import {
   updateDA,
   removeDA,
   updateFDAStatus,
+  updateFDAAgendaJobIds,
   createDatasource,
   retrieveDatasources,
   retrieveDatasource,
@@ -1393,7 +1394,8 @@ export async function deleteFDA(service, fdaId, visibility, servicePath) {
     targetServicePath = fda.servicePath;
   }
 
-  const { _id } = (await retrieveFDA(service, fdaId, targetServicePath)) ?? {};
+  const fda = await retrieveFDA(service, fdaId, targetServicePath);
+  const { _id } = fda ?? {};
 
   if (!service || !_id) {
     throw new FDAError(
@@ -1420,25 +1422,46 @@ export async function deleteFDA(service, fdaId, visibility, servicePath) {
   );
   await dropFiles(s3Client, bucketName, objPaths);
 
-  await removeFDA(service, fdaId, targetServicePath);
-
   const agenda = getAgenda();
-  await agenda.cancel(
-    buildFDAJobFilter(
-      'refresh-fda-recurring',
-      service,
-      fdaId,
-      targetServicePath,
-    ),
+  const agendaJobIds = await resolveFDAAgendaJobIds(
+    agenda,
+    fda,
+    targetServicePath,
   );
-  await agenda.cancel(
-    buildFDAJobFilter(
-      'clean-partition-recurring',
-      service,
-      fdaId,
-      targetServicePath,
-    ),
+
+  if (agendaJobIds.length > 0) {
+    await agenda.cancel({ ids: agendaJobIds });
+  }
+
+  await removeFDA(service, fdaId, targetServicePath);
+}
+
+async function resolveFDAAgendaJobIds(agenda, fda, servicePath) {
+  const storedJobIds = Array.isArray(fda?.agendaJobIds)
+    ? fda.agendaJobIds.filter(Boolean).map((jobId) => jobId.toString())
+    : [];
+
+  if (storedJobIds.length > 0) {
+    return storedJobIds;
+  }
+
+  const trackedJobs = await Promise.all(
+    ['refresh-fda-recurring', 'clean-partition-recurring'].map(async (name) => {
+      const result = await agenda.queryJobs({ names: [name] });
+      return result.jobs ?? [];
+    }),
   );
+
+  return trackedJobs
+    .flat()
+    .filter(
+      (job) =>
+        job.data?.service === fda.service &&
+        job.data?.fdaId === fda.fdaId &&
+        job.data?.servicePath === servicePath,
+    )
+    .map((job) => job._id?.toString())
+    .filter(Boolean);
 }
 
 export async function getDAs(service, fdaId, visibility, servicePath) {
@@ -1777,6 +1800,7 @@ function toFDAApiResponse(fda, { includeId }) {
   delete response.service;
   delete response.visibility;
   delete response.servicePath;
+  delete response.agendaJobIds;
 
   if (!includeId) {
     return response;
@@ -2081,6 +2105,7 @@ async function scheduleFDAJobs({
   datasourceId,
 }) {
   const { refreshInterval, windowSize } = refreshPolicy.params || {};
+  const agendaJobIds = [];
 
   const refreshJob = agenda.create('refresh-fda-recurring', {
     fdaId,
@@ -2098,6 +2123,9 @@ async function scheduleFDAJobs({
   );
   refreshJob.repeatEvery(refreshInterval, { skipImmediate: true });
   await refreshJob.save();
+  if (refreshJob.attrs._id) {
+    agendaJobIds.push(refreshJob.attrs._id.toString());
+  }
 
   if (windowSize) {
     const cleanPartitionJob = agenda.create('clean-partition-recurring', {
@@ -2118,6 +2146,18 @@ async function scheduleFDAJobs({
     );
     cleanPartitionJob.repeatEvery(refreshInterval, { skipImmediate: true });
     await cleanPartitionJob.save();
+    if (cleanPartitionJob.attrs._id) {
+      agendaJobIds.push(cleanPartitionJob.attrs._id.toString());
+    }
+  }
+
+  try {
+    await updateFDAAgendaJobIds(service, fdaId, servicePath, agendaJobIds);
+  } catch (error) {
+    if (agendaJobIds.length > 0) {
+      await agenda.cancel({ ids: agendaJobIds }).catch(() => {});
+    }
+    throw error;
   }
 }
 

--- a/src/lib/utils/mongo.js
+++ b/src/lib/utils/mongo.js
@@ -362,6 +362,7 @@ export async function createFDAMongo(
       status: initialStatus,
       progress: initialProgress,
       lastFetch: null,
+      agendaJobIds: [],
       refreshPolicy: refreshPolicy ?? { type: 'none' },
       ...(servicePath && { servicePath }),
       ...(description && { description }),
@@ -385,6 +386,24 @@ export async function createFDAMongo(
       );
     }
   }
+}
+
+export async function updateFDAAgendaJobIds(
+  service,
+  fdaId,
+  servicePath,
+  agendaJobIds,
+) {
+  const collection = await getCollection();
+
+  await collection.updateOne(
+    { service, fdaId, servicePath },
+    {
+      $set: {
+        agendaJobIds,
+      },
+    },
+  );
 }
 
 export async function updateFDAStatus(

--- a/test/integration/suites/fdaCreation.integration.tests.js
+++ b/test/integration/suites/fdaCreation.integration.tests.js
@@ -323,6 +323,143 @@ export function registerFdaCreationIntegrationTests({
     }
   });
 
+  test('DELETE /fdas only removes the target FDA recurring jobs', async () => {
+    const baseUrl = getBaseUrl();
+    const firstFdaId = 'fda_delete_jobs_a';
+    const secondFdaId = 'fda_delete_jobs_b';
+    const datasourceId = 'delete-jobs-ds';
+
+    const datasourceRes = await httpReq({
+      method: 'POST',
+      url: `${baseUrl}/datasources`,
+      headers: {
+        'Content-Type': 'application/json',
+        'Fiware-Service': service,
+      },
+      body: {
+        datasourceId,
+        type: 'postgres',
+        config: {
+          user: 'postgres',
+          password: 'postgres',
+          host: getPgHost(),
+          port: getPgPort(),
+          database: service,
+        },
+      },
+    });
+
+    expect(datasourceRes.status).toBe(200);
+
+    const createFda = async (id) => {
+      const res = await httpReq({
+        method: 'POST',
+        url: `${baseUrl}/${visibility}/fdas`,
+        headers: {
+          'Fiware-Service': service,
+          'Fiware-ServicePath': servicePath,
+        },
+        body: {
+          id,
+          query:
+            'SELECT id, name, age, timeinstant FROM public.users ORDER BY id',
+          description: `delete job ${id}`,
+          timeColumn: 'timeinstant',
+          datasourceId,
+          refreshPolicy: {
+            type: 'window',
+            params: {
+              refreshInterval: '1 hour',
+              fetchSize: 'day',
+              windowSize: 'day',
+            },
+          },
+          objStgConf: {
+            partition: 'day',
+          },
+        },
+      });
+
+      expect(res.status).toBe(202);
+      await waitUntilFDACompleted({ baseUrl, service, fdaId: id });
+    };
+
+    await createFda(firstFdaId);
+    await createFda(secondFdaId);
+
+    const mongoClient = new MongoClient(getMongoUri(), {
+      serverSelectionTimeoutMS: 10_000,
+    });
+
+    await mongoClient.connect();
+    try {
+      const collection = mongoClient.db().collection('agendaJobs');
+      const trackedNames = [
+        'refresh-fda-recurring',
+        'clean-partition-recurring',
+      ];
+      const recurringFilter = (fdaId) => ({
+        name: { $in: trackedNames },
+        'data.service': service,
+        'data.servicePath': servicePath,
+        'data.fdaId': fdaId,
+      });
+
+      const deadline = Date.now() + 10_000;
+      let firstJobs = 0;
+      let secondJobs = 0;
+      while (Date.now() < deadline) {
+        firstJobs = await collection.countDocuments(
+          recurringFilter(firstFdaId),
+        );
+        secondJobs = await collection.countDocuments(
+          recurringFilter(secondFdaId),
+        );
+        if (firstJobs === 2 && secondJobs === 2) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+
+      expect(firstJobs).toBe(2);
+      expect(secondJobs).toBe(2);
+
+      const deleteRes = await httpReq({
+        method: 'DELETE',
+        url: `${baseUrl}/${visibility}/fdas/${firstFdaId}`,
+        headers: {
+          'Fiware-Service': service,
+          'Fiware-ServicePath': servicePath,
+        },
+      });
+
+      expect(deleteRes.status).toBe(204);
+
+      const finalDeadline = Date.now() + 10_000;
+      let remainingFirstJobs = 0;
+      let remainingSecondJobs = 0;
+      while (Date.now() < finalDeadline) {
+        remainingFirstJobs = await collection.countDocuments(
+          recurringFilter(firstFdaId),
+        );
+        remainingSecondJobs = await collection.countDocuments(
+          recurringFilter(secondFdaId),
+        );
+
+        if (remainingFirstJobs === 0 && remainingSecondJobs === 2) {
+          break;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+
+      expect(remainingFirstJobs).toBe(0);
+      expect(remainingSecondJobs).toBe(2);
+    } finally {
+      await mongoClient.close();
+    }
+  });
+
   test('POST /fdas tries to creates an FDA without id and is detected', async () => {
     const baseUrl = getBaseUrl();
     const res = await httpReq({

--- a/test/unit/fda.test.js
+++ b/test/unit/fda.test.js
@@ -68,6 +68,7 @@ const mongoMocks = {
   updateDA: jest.fn(),
   removeDA: jest.fn(),
   updateFDAStatus: jest.fn(),
+  updateFDAAgendaJobIds: jest.fn(),
   createDatasource: jest.fn(),
   retrieveDatasources: jest.fn(),
   retrieveDatasource: jest.fn(),
@@ -129,6 +130,7 @@ await jest.unstable_mockModule('../../src/lib/utils/mongo.js', () => ({
   updateDA: mongoMocks.updateDA,
   removeDA: mongoMocks.removeDA,
   updateFDAStatus: mongoMocks.updateFDAStatus,
+  updateFDAAgendaJobIds: mongoMocks.updateFDAAgendaJobIds,
   createDatasource: mongoMocks.createDatasource,
   retrieveDatasources: mongoMocks.retrieveDatasources,
   retrieveDatasource: mongoMocks.retrieveDatasource,
@@ -1009,6 +1011,7 @@ describe('fetchFDA', () => {
       done: jest.fn().mockResolvedValue(undefined),
     });
     mongoMocks.createFDAMongo.mockResolvedValue(undefined);
+    mongoMocks.updateFDAAgendaJobIds.mockResolvedValue(undefined);
     mongoMocks.removeFDA.mockResolvedValue(undefined);
     mongoMocks.readMongoDatasourceRows.mockResolvedValue([]);
     dbMocks.getDBConnection.mockResolvedValue({});
@@ -1021,9 +1024,13 @@ describe('fetchFDA', () => {
       const job = {
         name,
         data,
+        attrs: {},
         unique: jest.fn().mockReturnThis(),
         repeatEvery: jest.fn().mockReturnThis(),
-        save: jest.fn().mockResolvedValue(undefined),
+        save: jest.fn().mockImplementation(async () => {
+          job.attrs._id = `${name}-id`;
+          return job;
+        }),
       };
 
       return job;
@@ -1762,7 +1769,12 @@ describe('fetchFDA', () => {
       skipImmediate: true,
     });
     expect(refreshJob.save).toHaveBeenCalled();
-    expect(refreshJob.save).toHaveBeenCalled();
+    expect(mongoMocks.updateFDAAgendaJobIds).toHaveBeenCalledWith(
+      'svc',
+      'fda1',
+      '/servicepath',
+      ['refresh-fda-recurring-id'],
+    );
   });
 
   test('fails when refresh interval is larger than partition size', async () => {
@@ -1867,6 +1879,12 @@ describe('fetchFDA', () => {
       skipImmediate: true,
     });
     expect(cleanJob.save).toHaveBeenCalled();
+    expect(mongoMocks.updateFDAAgendaJobIds).toHaveBeenCalledWith(
+      'svc',
+      'fda1',
+      '/servicepath',
+      ['refresh-fda-recurring-id', 'clean-partition-recurring-id'],
+    );
 
     const refreshJob = agenda.create.mock.results.find(
       ({ value }) => value.name === 'refresh-fda-recurring',
@@ -2465,6 +2483,7 @@ describe('deleteFDA', () => {
       _id: 'mongo-id',
       visibility: 'private',
       servicePath: '/servicepath',
+      agendaJobIds: ['refresh-job-id', 'clean-job-id'],
     });
     awsMocks.listObjects.mockResolvedValue(['servicepath/fdaA.parquet']);
 
@@ -2479,18 +2498,9 @@ describe('deleteFDA', () => {
       '/servicepath',
     );
     expect(agenda.cancel).toHaveBeenCalledWith({
-      name: 'refresh-fda-recurring',
-      'data.service': 'svc',
-      'data.fdaId': 'fdaA',
-      'data.servicePath': '/servicepath',
+      ids: ['refresh-job-id', 'clean-job-id'],
     });
-    expect(agenda.cancel).toHaveBeenCalledWith({
-      name: 'clean-partition-recurring',
-      'data.service': 'svc',
-      'data.fdaId': 'fdaA',
-      'data.servicePath': '/servicepath',
-    });
-    expect(agenda.cancel).toHaveBeenCalledTimes(2);
+    expect(agenda.cancel).toHaveBeenCalledTimes(1);
   });
 
   test('deleteFDA uses normalized bucket name for object storage deletion', async () => {
@@ -2498,6 +2508,7 @@ describe('deleteFDA', () => {
       _id: 'mongo-id',
       visibility: 'private',
       servicePath: '/servicepath',
+      agendaJobIds: ['refresh-job-id', 'clean-job-id'],
     });
     awsMocks.listObjects.mockResolvedValue(['servicepath/fdaA.parquet']);
 
@@ -2518,6 +2529,7 @@ describe('deleteFDA', () => {
       _id: 'mongo-id',
       visibility: 'private',
       servicePath: '/test',
+      agendaJobIds: ['refresh-job-id', 'clean-job-id'],
     });
     // listObjects returns objects for both fda_test and fda_test_1 because S3
     // prefix listing matches any key starting with "test/fda_test"
@@ -2542,6 +2554,7 @@ describe('deleteFDA', () => {
       _id: 'mongo-id',
       visibility: 'private',
       servicePath: '/servicepath',
+      agendaJobIds: ['refresh-job-id', 'clean-job-id'],
     });
     awsMocks.listObjects.mockResolvedValue([]);
 
@@ -2554,18 +2567,9 @@ describe('deleteFDA', () => {
       '/servicepath',
     );
     expect(agenda.cancel).toHaveBeenCalledWith({
-      name: 'refresh-fda-recurring',
-      'data.service': 'svc',
-      'data.fdaId': 'fdaA',
-      'data.servicePath': '/servicepath',
+      ids: ['refresh-job-id', 'clean-job-id'],
     });
-    expect(agenda.cancel).toHaveBeenCalledWith({
-      name: 'clean-partition-recurring',
-      'data.service': 'svc',
-      'data.fdaId': 'fdaA',
-      'data.servicePath': '/servicepath',
-    });
-    expect(agenda.cancel).toHaveBeenCalledTimes(2);
+    expect(agenda.cancel).toHaveBeenCalledTimes(1);
   });
 
   test('throws FDANotFound when FDA does not exist', async () => {
@@ -2746,9 +2750,13 @@ describe('fetchFDA with refresh policies', () => {
       const job = {
         name,
         data,
+        attrs: {},
         unique: jest.fn().mockReturnThis(),
         repeatEvery: jest.fn().mockReturnThis(),
-        save: jest.fn().mockResolvedValue(undefined),
+        save: jest.fn().mockImplementation(async () => {
+          job.attrs._id = `${name}-id`;
+          return job;
+        }),
       };
 
       return job;
@@ -3050,24 +3058,16 @@ describe('deleteFDA', () => {
       _id: 'mongo-id',
       visibility: 'private',
       servicePath: '/servicepath',
+      agendaJobIds: ['refresh-job-id', 'clean-job-id'],
     });
     awsMocks.listObjects.mockResolvedValue(['fda1.parquet']);
 
     await deleteFDA('svc', 'fda1', 'private', '/servicepath');
 
-    expect(agenda.cancel).toHaveBeenNthCalledWith(1, {
-      name: 'refresh-fda-recurring',
-      'data.service': 'svc',
-      'data.fdaId': 'fda1',
-      'data.servicePath': '/servicepath',
+    expect(agenda.cancel).toHaveBeenCalledWith({
+      ids: ['refresh-job-id', 'clean-job-id'],
     });
-    expect(agenda.cancel).toHaveBeenNthCalledWith(2, {
-      name: 'clean-partition-recurring',
-      'data.service': 'svc',
-      'data.fdaId': 'fda1',
-      'data.servicePath': '/servicepath',
-    });
-    expect(agenda.cancel).toHaveBeenCalledTimes(2);
+    expect(agenda.cancel).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
Note that 

* Up to 205e4ef: sync from current (wrong) 1.1.2 created at main branch
* efae44d: solving conflict to include the missing line in Changelg(see PR https://github.com/telefonicaid/fiware-data-access/pull/226)

<img width="1393" height="350" alt="imagen" src="https://github.com/user-attachments/assets/e3c5d57a-3789-43bd-911b-66c49524c65a" />
