### PR TITLE
Leftover: AgendaJobsId revert

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,3 @@
-- Fix: FDA scheduled job cleanup now cancels Agenda jobs by persisted IDs (`agendaJobIds`) to prevent deleting jobs from other FDAs with the same recurring job name (**)
-- Migration: FDA documents now include `agendaJobIds` (`string[]`). Legacy FDAs without this field can still be deleted, but cleanup relies on runtime job lookup fallback; to guarantee deterministic cleanup in all environments, backfill `agendaJobIds` or recreate those FDAs (**)
 - Add: support CDA-compatible JSON output format (`outputType=cda` and `Accept: application/vnd.fiware.cda+json`) for FDA data endpoints (#204) (*)
 - Add: MongoDB datasource support as a new datasource type, including connection validation, cached-only FDA support, Mongo-specific contract and full ingestion pipeline integration (#176) (*)
 - Fix: prevent recurring Agenda jobs from being overwritten across FDAs by using per-FDA recurring job identity and scheduling (#206) (*)

--- a/doc/02_architecture.md
+++ b/doc/02_architecture.md
@@ -193,7 +193,6 @@ Each DA contains:
     "progress": 10,
     "initFetch": "2026-02-19T07:37:52.084Z",
     "lastFetch": null,
-    "agendaJobIds": ["6a4647d198863226b8001614"],
     "visibility": "public",
     "validationMode": "strict",
     "schema": [

--- a/doc/AdvancedTopics/async_processing_and_jobs.md
+++ b/doc/AdvancedTopics/async_processing_and_jobs.md
@@ -282,16 +282,6 @@ This means:
 Recurring jobs are created using `agenda.create()`, configured with `repeatEvery()`, and persisted via `save()`. A
 `unique()` filter prevents duplicate recurring jobs from being created for the same FDA.
 
-When an FDA is deleted, recurring jobs are cancelled by their stored Agenda job IDs rather than by filtering on nested
-`data.*` fields.
-
-> **Compatibility note:** This project currently uses `agenda` 6.2.3 with `@agendajs/mongo-backend` 3.2.0. These
-> versions do not support partial matching on nested `data.*` fields in `agenda.cancel()`. This limitation has been
-> fixed upstream (Agenda PR #1679) and should be checked. Job IDs are therefore persisted to ensure precise cancellation
-> until the dependency is upgraded.
->
-> -   [Agenda PR #1679 – Partial matching on data subdocuments](https://github.com/agenda/agenda/pull/1679)
-
 ---
 
 ## 9. Failure Handling & Backoff Strategies


### PR DESCRIPTION
In comment https://github.com/telefonicaid/fiware-data-access/issues/206#issuecomment-4890971865 we talked about reverting a workaround with `Agenda Jobs` because we updated the library to the latest version, but we had leftover documentation about it.